### PR TITLE
Check for the existence of `jq` before continuing

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -7,6 +7,14 @@ then
     USE_GLOW=false
 fi
 
+# Check for the existence of jq, since it's required.
+if ! command -v jq &> /dev/null
+then
+    echo "jq not found. Please install it, first, then re-run this command."
+    # Exit
+    exit
+fi
+
 unalias -a
 
 HELPSTRING="""\


### PR DESCRIPTION
If `jq` isn't installed, the rest of the program isn't going to work. Check and bail out if it's not, telling the user what they need to do, otherwise, continue.