### PR TITLE
Typo fix for rbenv, add quote to solargraph

### DIFF
--- a/programs/rbenv.json
+++ b/programs/rbenv.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.rbenv",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport RBENV_ROOT=XDG_DATA_HOME/rbenv\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport RBENV_ROOT=\"$XDG_DATA_HOME\"/rbenv\n```\n"
         }
     ],
     "name": "rbenv"

--- a/programs/solargraph.json
+++ b/programs/solargraph.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.solargraph/cache/",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport SOLARGRAPH_CACHE=$XDG_CACHE_HOME/solargraph \n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport SOLARGRAPH_CACHE=\"$XDG_CACHE_HOME\"/solargraph \n```\n"
         }
     ],
     "name": "solargraph"


### PR DESCRIPTION
The `$` character is missed in `rbenv` case, and the `solargraph`'s variable is not properly quoted like others suggestion.