### PR TITLE
Make the script callable in more places

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -166,7 +166,7 @@ check_program() {
 enumerate_programs() {
     echo -e "\e[1;3mStarting to check your \e[1;36m\$HOME.\e[1;0m"
     echo -e ""
-    for prog_filename in ./programs/*; do
+	for prog_filename in "$(dirname "${BASH_SOURCE[0]}")"/programs/*; do
         check_program "$(cat $prog_filename)"
     done
     echo -e "\e[1;3mDone checking your \e[1;36m\$HOME.\e[1;0m"

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 USE_GLOW=true
 if ! command -v glow &> /dev/null


### PR DESCRIPTION
By using `/usr/bin/env bash` instead of `/bin/bash` this script can be called in distrubtions such as NixOS who don't have a /bin/bash.

By using a path relative to the script and not to the CWD we can run the script from anywhere.