### PR TITLE
Fixed Xresources message

### DIFF
--- a/programs/xorg-xrdb.json
+++ b/programs/xorg-xrdb.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.Xresources",
             "movable": true,
-            "help": "xrdb loads these resources, wherever you call xrdb, add this flag:\n\n```bash\nxrdb -load \"$XDG_CONFIG_HOME/.config/X11/xresources\"\n```\n\n_Note: It will probably be called by your Xsession file._\n"
+            "help": "xrdb loads these resources, wherever you call xrdb, add this flag:\n\n```bash\nxrdb -load \"$XDG_CONFIG_HOME/X11/xresources\"\n```\n\n_Note: It will probably be called by your Xsession file._\n"
         }
     ],
     "name": "xorg-xrdb"


### PR DESCRIPTION
Xresources message shows incorrect export variable suggestion. Fixed to correct value.