### PR TITLE
Added line break when glow is not installed

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -3,9 +3,9 @@
 
 USE_GLOW=true
 if ! command -v glow >/dev/null 2>/dev/null; then
-    printf "Glow not found, markdown rendering not available."
-    printf "Output will be raw markdown and might look weird."
-    printf "Install glow for easier reading & copy-paste."
+    printf "Glow not found, markdown rendering not available.\n"
+    printf "Output will be raw markdown and might look weird.\n"
+    printf "Install glow for easier reading & copy-paste.\n"
     USE_GLOW=false
 fi
 


### PR DESCRIPTION
The error messages, for when `glow` is not installed, do not have line breaks/ spaces in between. That results in this not so nicely 
formatted message, which is in one line without spaces between the sentences: 
```
Glow not found, markdown rendering not available.Output will be raw markdown and might look weird.Install glow for easier reading & copy-paste.The $XDG_DATA_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!
```

Since the code had different `printf` commands for the sentences, I added line breaks instead of spaces.
The error message is now much more readable and can better be distinguished from the `$XDG_DATA_HOME` error message.
```
Glow not found, markdown rendering not available.
Output will be raw markdown and might look weird.
Install glow for easier reading & copy-paste.
The $XDG_DATA_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!
```