### PR TITLE
xdg-ninja: change jq json source

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -166,14 +166,14 @@ check_file() {
 
 # Reads a file from programs/, calls check_file on each file specified for the program
 check_program() {
-    INPUT=$1
+    PROGRAM=$1
 
-    NAME=$(printf "%s" "$INPUT" | jq -r .name)
+    NAME=$(jq -r .name "$PROGRAM")
 
     while IFS= read -r file; do
         check_file "$file" "$NAME"
     done <<EOF
-$(echo "$INPUT" | jq -rc '.files[]')
+$(jq -rc '.files[]' "$PROGRAM")
 EOF
 }
 
@@ -182,7 +182,7 @@ enumerate_programs() {
     printf "\e[1;3mStarting to check your \e[1;36m\$HOME.\e[1;0m\n"
     printf "\n"
     for prog_filename in "${0%/*}"/programs/*; do
-        check_program "$(cat "$prog_filename")"
+        check_program "$prog_filename"
     done
     printf "\e[1;3mDone checking your \e[1;36m\$HOME.\e[1;0m\n"
     printf "\n"


### PR DESCRIPTION
There was an issue caused by inconsistencies on the implementation of echo through different shells. Some, like bash, did not interpret \n while others, like dash, did. This caused issue when sending the information to jq to parse as it as JSON specifications forbids multi-line strings.

A quick fix was applied by giving jq the path to the file to analyze rather than grabbing it from stdin.

Fixes #22 