### PR TITLE
Add support for bat for markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This will run every test in the default configuration.
 
 ### Optional
 
-- [glow](https://repology.org/project/glow/packages) for rendering markdown in the terminal
+- [glow](https://repology.org/project/glow/packages) or [bat](https://repology.org/project/bat-cat/packages) for rendering markdown in the terminal
 - [cabal](https://repology.org/project/cabal/packages) for compiling the helper program for creating configurations
 
 ## Configuration

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env sh
 # shellcheck disable=SC2016
 
-USE_GLOW=true
-if ! command -v glow >/dev/null 2>/dev/null; then
-    printf "Glow not found, markdown rendering not available.\n"
+USE_GLOW=false
+USE_BAT=false
+if command -v glow >/dev/null 2>/dev/null; then
+    USE_GLOW=true
+elif command -v bat >/dev/null 2>/dev/null; then
+    USE_BAT=true
+else
+    printf "Glow or bat not found, markdown rendering not available.\n"
     printf "Output will be raw markdown and might look weird.\n"
-    printf "Install glow for easier reading & copy-paste.\n"
-    USE_GLOW=false
+    printf "Install glow or bat for easier reading & copy-paste.\n"
 fi
 
 unalias -a
@@ -123,6 +127,8 @@ log() {
     HELP)
         if $USE_GLOW; then
             printf "%s" "$HELP" | glow -
+        elif $USE_BAT; then
+            printf "%s" "$HELP" | bat -pp -f --language markdown
         else
             printf "%s" "$HELP"
         fi

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -126,11 +126,11 @@ log() {
 
     HELP)
         if $USE_GLOW; then
-            printf "%s" "$HELP" | glow -
+            printf "%s\n" "$HELP" | glow -
         elif $USE_BAT; then
-            printf "%s" "$HELP" | bat -pp -f --language markdown
+            printf "%s\n" "$HELP" | bat -pp -f --language markdown
         else
-            printf "%s" "$HELP"
+            printf "%s\n" "$HELP"
         fi
         ;;
 


### PR DESCRIPTION
`bat` can render markdown to terminal. It is also more probable to be installed on user's system.
Nevertheless, this PR prioritizes `glow` for markdown rendering, if it is not found it tries to use `bat`. 

Also add a newline to log HELP to increase readability.