### PR TITLE
Fix escape codes for POSIX `sh`

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -20,19 +20,19 @@ unalias -a
 HELPSTRING="""\
 
 
-    \e[37;45;1mxdg-ninja\e[0m
+    \033[37;45;1mxdg-ninja\033[0m
 
-    \e[1;3mCheck your \$HOME for unwanted files.\e[1;0m
+    \033[1;3mCheck your \$HOME for unwanted files.\033[1;0m
 
     ────────────────────────────────────
 
-    \e[3m--help\e[0m              \e[1mThis help menu\e[0m
-    \e[3m-h\e[0m
+    \033[3m--help\033[0m              \033[1mThis help menu\033[0m
+    \033[3m-h\033[0m
 
-    \e[3m--no-skip-ok\e[0m        \e[1mDisplay messages for all files checked (verbose)\e[0m
-    \e[3m-v\e[0m
+    \033[3m--no-skip-ok\033[0m        \033[1mDisplay messages for all files checked (verbose)\033[0m
+    \033[3m-v\033[0m
 
-    \e[3m--skip-ok\e[0m           \e[1mDon't display anything for files that do not exist (default)\e[0m
+    \033[3m--skip-ok\033[0m           \033[1mDon't display anything for files that do not exist (default)\033[0m
 
 """
 
@@ -51,24 +51,24 @@ for i in "$@"; do
 done
 
 if [ -z "${XDG_DATA_HOME}" ]; then
-    printf '\e[1;36m%s\e[1;0m\n' "The \$XDG_DATA_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
-    printf '\e[1;36m    ⤷ \e[1mThe recommended value is: \e[1;3m$HOME/.local/share\e[1;0m\n'
+    printf '\033[1;36m%s\033[1;0m\n' "The \$XDG_DATA_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
+    printf '\033[1;36m    ⤷ \033[1mThe recommended value is: \033[1;3m$HOME/.local/share\033[1;0m\n'
 fi
 if [ -z "${XDG_CONFIG_HOME}" ]; then
-    printf '\e[1;36m%s\e[1;0m\n' "The \$XDG_CONFIG_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
-    printf '\e[1;36m    ⤷ \e[1mThe recommended value is: \e[1;3m$HOME/.config\e[1;0m\n'
+    printf '\033[1;36m%s\033[1;0m\n' "The \$XDG_CONFIG_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
+    printf '\033[1;36m    ⤷ \033[1mThe recommended value is: \033[1;3m$HOME/.config\033[1;0m\n'
 fi
 if [ -z "${XDG_STATE_HOME}" ]; then
-    printf '\e[1;36m%s\e[1;0m\n' "The \$XDG_STATE_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
-    printf '\e[1;36m    ⤷ \e[1mThe recommended value is: \e[1;3m$HOME/.local/state\e[1;0m\n'
+    printf '\033[1;36m%s\033[1;0m\n' "The \$XDG_STATE_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
+    printf '\033[1;36m    ⤷ \033[1mThe recommended value is: \033[1;3m$HOME/.local/state\033[1;0m\n'
 fi
 if [ -z "${XDG_CACHE_HOME}" ]; then
-    printf '\e[1;36m%s\e[1;0m\n' "The \$XDG_CACHE_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
-    printf '\e[1;36m    ⤷ \e[1mThe recommended value is: \e[1;3m$HOME/.cache\e[1;0m\n'
+    printf '\033[1;36m%s\033[1;0m\n' "The \$XDG_CACHE_HOME environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
+    printf '\033[1;36m    ⤷ \033[1mThe recommended value is: \033[1;3m$HOME/.cache\033[1;0m\n'
 fi
 if [ -z "${XDG_RUNTIME_DIR}" ]; then
-    printf '\e[1;36m%s\e[1;0m\n' "The \$XDG_RUNTIME_DIR environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
-    printf '\e[1;36m    ⤷ \e[1mThe recommended value is: \e[1;3m/run/user/$UID\e[1;0m\n'
+    printf '\033[1;36m%s\033[1;0m\n' "The \$XDG_RUNTIME_DIR environment variable is not set, make sure to add it to your shell's configuration before setting any of the other environment variables!"
+    printf '\033[1;36m    ⤷ \033[1mThe recommended value is: \033[1;3m/run/user/$UID\033[1;0m\n'
 fi
 
 if ! command -v jq >/dev/null 2>/dev/null; then
@@ -110,20 +110,20 @@ log() {
     case "$MODE" in
 
     ERR)
-        printf '[\e[1;31m%s\e[1;0m]: \e[1;3m%s\e[1;0m\n' "$NAME" "$FILENAME"
+        printf '[\033[1;31m%s\033[1;0m]: \033[1;3m%s\033[1;0m\n' "$NAME" "$FILENAME"
         ;;
 
     WARN)
-        printf '[\e[1;33m%s\e[1;0m]: \e[1;3m%s\e[1;0m\n' "$NAME" "$FILENAME"
+        printf '[\033[1;33m%s\033[1;0m]: \033[1;3m%s\033[1;0m\n' "$NAME" "$FILENAME"
         ;;
 
     INFO)
-        printf '[\e[1;36m%s\e[1;0m]: \e[1;3m%s\e[1;0m\n' "$NAME" "$FILENAME"
+        printf '[\033[1;36m%s\033[1;0m]: \033[1;3m%s\033[1;0m\n' "$NAME" "$FILENAME"
         ;;
 
     SUCS)
         [ "$SKIP_OK" = false ] &&
-            printf '[\e[1;32m%s\e[1;0m]: \e[1;3m%s\e[1;0m\n' "$NAME" "$FILENAME"
+            printf '[\033[1;32m%s\033[1;0m]: \033[1;3m%s\033[1;0m\n' "$NAME" "$FILENAME"
         ;;
 
     HELP)
@@ -187,14 +187,14 @@ EOF
 
 # Loops over all files in the programs/ directory and calls check_program
 enumerate_programs() {
-    printf "\e[1;3mStarting to check your \e[1;36m\$HOME.\e[1;0m\n"
+    printf "\033[1;3mStarting to check your \033[1;36m\$HOME.\033[1;0m\n"
     printf "\n"
     for prog_filename in "${0%/*}"/programs/*; do
         check_program "$prog_filename"
     done
-    printf "\e[1;3mDone checking your \e[1;36m\$HOME.\e[1;0m\n"
+    printf "\033[1;3mDone checking your \033[1;36m\$HOME.\033[1;0m\n"
     printf "\n"
-    printf "\e[3mIf you have files in your \e[1;36m\$HOME\e[1;0m that shouldn't be there, but weren't recognised by xdg-ninja, please consider creating a configuration file for it and opening a pull request on github.\e[1;0m\n"
+    printf "\033[3mIf you have files in your \033[1;36m\$HOME\033[1;0m that shouldn't be there, but weren't recognised by xdg-ninja, please consider creating a configuration file for it and opening a pull request on github.\033[1;0m\n"
     printf "\n"
 }
 


### PR DESCRIPTION
`\e` works with shells like bash and zsh, but not with dash.
`\033` is portable and POSIX compliant.