### PR TITLE
fix dirname

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -189,7 +189,7 @@ EOF
 enumerate_programs() {
     printf "\033[1;3mStarting to check your \033[1;36m\$HOME.\033[1;0m\n"
     printf "\n"
-    for prog_filename in "${0%/*}"/programs/*; do
+    for prog_filename in "$(dirname $0)"/programs/*; do
         check_program "$prog_filename"
     done
     printf "\033[1;3mDone checking your \033[1;36m\$HOME.\033[1;0m\n"

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -189,7 +189,7 @@ EOF
 enumerate_programs() {
     printf "\033[1;3mStarting to check your \033[1;36m\$HOME.\033[1;0m\n"
     printf "\n"
-    for prog_filename in "$(dirname $0)"/programs/*; do
+    for prog_filename in "$(dirname "$0")"/programs/*; do
         check_program "$prog_filename"
     done
     printf "\033[1;3mDone checking your \033[1;36m\$HOME.\033[1;0m\n"


### PR DESCRIPTION
When calling xdg-ninja.sh using
`sh xdg-ninja.sh`
or
`bash xdg-ninja.sh`

the script fails with
```
jq: error: Could not open file xdg-ninja.sh/programs/*: Not a directory
jq: error: Could not open file xdg-ninja.sh/programs/*: Not a directory
Done checking your $HOME.
```

This commit just fixes that problem.