### PR TITLE
Fix typos in .json

### DIFF
--- a/programs/aria2.json
+++ b/programs/aria2.json
@@ -3,12 +3,12 @@
     "files": [
         {
             "path": "${HOME}/.aria2/dht.dat",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.aria2/dht.dat can be moved to ${XDG_CACHE_HOME}/aria2/dht.dat.\n"
         },
         {
             "path": "${HOME}/.aria2/aria.conf",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.aria2/aria.conf can be moved to ${XDG_CONFIG_HOME}/aria2/aria2.conf.\n"
         }
     ]

--- a/programs/bash.json
+++ b/programs/bash.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.bash_history",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport HISTFILE=${XDG_CACHE_HOME}/bash/history\n```\n"
         }
     ]

--- a/programs/ccache.json
+++ b/programs/ccache.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.ccache",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport CCACHE_DIR=${XDG_CACHE_HOME}/ccache\n```\n"
         }
     ]

--- a/programs/chez.json
+++ b/programs/chez.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.chezscheme_history",
-            "moveable": true,
+            "movable": true,
             "help": "Alias petite to use custom locations:\n\n```bash\nalias petite=petite --eehistory ${XDG_DATA_HOME}/chezscheme/history\nalias scheme=scheme --eehistory ${XDG_DATA_HOME}/chezscheme/history```\n"
         }
     ]

--- a/programs/fontconfig.json
+++ b/programs/fontconfig.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.fontconfig",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.fontconfig can be moved to ${XDG_DATA_HOME}/fontconfig.\n"
         }
     ]

--- a/programs/fonts.json
+++ b/programs/fonts.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.fonts",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.fonts can be moved to ${XDG_DATA_HOME}/fonts.\n"
         }
     ]

--- a/programs/gdb.json
+++ b/programs/gdb.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.gdbinit",
-            "moveable": true,
+            "movable": true,
             "help": "Alias gdb to use custom locations:\n\n```bash\nalias gdb=gdb -n -x $XDG_CONFIG_HOME/gdb/init```\n"
         }
     ]

--- a/programs/gem.json
+++ b/programs/gem.json
@@ -3,17 +3,17 @@
     "files": [
         {
             "path": "${HOME}/.gem/ruby",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.gem/ruby can be moved to ${XDG_CONFIG_HOME}/gem.\n"
         },
         {
             "path": "${HOME}/.gem",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport GEM_HOME=${XDG_DATA_HOME}/gem\n```\n"
         },
         {
             "path": "${HOME}/.gem/specs",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport GEM_SPEC_CACHE=${XDG_CACHE_HOME}/gem\n```\n"
         }
     ]

--- a/programs/httpie.json
+++ b/programs/httpie.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.httpie",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.httpie can be moved to ${XDG_CONFIG_HOME}/httpie.\n"
         }
     ]

--- a/programs/less.json
+++ b/programs/less.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.lesshst",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport LESSHISTFILE=${XDG_CACHE_HOME}/less/history\n```\n"
         }
     ]

--- a/programs/lnav.json
+++ b/programs/lnav.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.lnav",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.lnav can be moved to ${XDG_CONFIG_HOME}/lnav.\n"
         }
     ]

--- a/programs/mapscii.json
+++ b/programs/mapscii.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.mapscii",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.mapscii can be moved to ${XDG_CACHE_HOME}/mapscii.\n"
         }
     ]

--- a/programs/pex.json
+++ b/programs/pex.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.pex",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport PEX_ROOT=${XDG_CACHE_HOME}/pex\n```\n"
         }
     ]

--- a/programs/pylint.json
+++ b/programs/pylint.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.pylint.d",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport PYLINTHOME=${XDG_CACHE_HOME}/pylint\n```\n"
         }
     ]

--- a/programs/qrcp.json
+++ b/programs/qrcp.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.qrcp",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.qrcp can be moved to ${XDG_CONFIG_HOME}/qrcp/config.json.\n"
         }
     ]

--- a/programs/racket.json
+++ b/programs/racket.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.racket",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.racket can be moved to ${XDG_CONFIG_HOME}/racket.\n"
         }
     ]

--- a/programs/tig.json
+++ b/programs/tig.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.tig_history",
-            "moveable": true,
+            "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.tig_history can be moved to ${XDG_DATA_HOME}/tig/history.\n"
         }
     ]

--- a/programs/weechat.json
+++ b/programs/weechat.json
@@ -3,7 +3,7 @@
     "files": [
         {
             "path": "${HOME}/.weechat",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport WEECHAT_HOME=${XDG_CONFIG_HOME}/weechat\n```\nAlias weechat to use custom locations:\n\n```bash\nalias weechat=weechat -d ${XDG_CONFIG_HOME}/weechat```\n"
         }
     ]

--- a/programs/xcompose.json
+++ b/programs/xcompose.json
@@ -3,12 +3,12 @@
     "files": [
         {
             "path": "${HOME}/.XCompose",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport XCOMPOSEFILE=${XDG_CONFIG_HOME}/X11/xcompose\n```\n"
         },
         {
             "path": "${HOME}/.compose-cache",
-            "moveable": true,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport XCOMPOSECACHE=${XDG_CACHE_HOME}/X11/xcompose\n```\n"
         }
     ]


### PR DESCRIPTION
In some .jsons the field name was moveable instead of movable. This results in some errors as we [query for movable in xdg-ninja.sh](https://github.com/b3nj5m1n/xdg-ninja/blob/c80f3f88dc3dd768fb690d49a7ec4bfcb7cf4bc0/xdg-ninja.sh#L147).
This PR simply replaces any occurence of moveable with movable.