### PR TITLE
sqlite: suggest XDG_CACHE_HOME instead of XDG_DATA_HOME

### DIFF
--- a/programs/sqlite.json
+++ b/programs/sqlite.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.sqlite_history",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport SQLITE_HISTORY=$XDG_DATA_HOME/sqlite_history\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport SQLITE_HISTORY=$XDG_CACHE_HOME/sqlite_history\n```\n"
         }
     ],
     "name": "sqlite"


### PR DESCRIPTION
Since it is a history file, i would consider it non-essential.