### PR TITLE
Double quote `$XDG...` in shell exports

### DIFF
--- a/programs/android-studio.json
+++ b/programs/android-studio.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.android",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport ANDROID_HOME=$XDG_DATA_HOME/android\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport ANDROID_HOME=\"$XDG_DATA_HOME\"/android\n```\n"
         }
     ],
     "name": "android-studio"

--- a/programs/asdf-vm.json
+++ b/programs/asdf-vm.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.asdf",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport ASDF_DATA_DIR=${XDG_DATA_HOME}/asdf\"\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport ASDF_DATA_DIR=\"${XDG_DATA_HOME}\"/asdf\"\n```\n"
         },
         {
             "path": "$HOME/.asdfrc",

--- a/programs/bash.json
+++ b/programs/bash.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.bash_history",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport HISTFILE=${XDG_STATE_HOME}/bash/history\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport HISTFILE=\"${XDG_STATE_HOME}\"/bash/history\n```\n"
         }
     ]
 }

--- a/programs/ccache.json
+++ b/programs/ccache.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.ccache",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport CCACHE_DIR=${XDG_CACHE_HOME}/ccache\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport CCACHE_DIR=\"${XDG_CACHE_HOME}\"/ccache\n```\n"
         }
     ]
 }

--- a/programs/cd-bookmark.json
+++ b/programs/cd-bookmark.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.cdbookmark",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport CD_BOOKMARK_FILE=$XDG_CONFIG_HOME/cd-bookmark/bookmarks\n```\n\n_There's also a [fork](https://github.com/erikw/cd-bookmark/) with XDG support built-in._\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport CD_BOOKMARK_FILE=\"$XDG_CONFIG_HOME\"/cd-bookmark/bookmarks\n```\n\n_There's also a [fork](https://github.com/erikw/cd-bookmark/) with XDG support built-in._\n"
         }
     ],
     "name": "cd-bookmark"

--- a/programs/cgdb.json
+++ b/programs/cgdb.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.cgdb",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport CGDB_DIR=$XDG_CONFIG_HOME/cgdb\n```\n\nMove the configuration file to _XDG_CONFIG_HOME/cgdb/cgdbrc_\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport CGDB_DIR=\"$XDG_CONFIG_HOME\"/cgdb\n```\n\nMove the configuration file to _XDG_CONFIG_HOME/cgdb/cgdbrc_\n"
         }
     ],
     "name": "cgdb"

--- a/programs/gem.json
+++ b/programs/gem.json
@@ -9,12 +9,12 @@
         {
             "path": "${HOME}/.gem",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport GEM_HOME=${XDG_DATA_HOME}/gem\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport GEM_HOME=\"${XDG_DATA_HOME}\"/gem\n```\n"
         },
         {
             "path": "${HOME}/.gem/specs",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport GEM_SPEC_CACHE=${XDG_CACHE_HOME}/gem\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport GEM_SPEC_CACHE=\"${XDG_CACHE_HOME}\"/gem\n```\n"
         }
     ]
 }

--- a/programs/kodi.json
+++ b/programs/kodi.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.kodi",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nKODI_DATA=$XDG_DATA_HOME/kodi\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport KODI_DATA=\"$XDG_DATA_HOME\"/kodi\n```\n"
         }
     ],
     "name": "kodi"

--- a/programs/less.json
+++ b/programs/less.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.lesshst",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport LESSHISTFILE=${XDG_CACHE_HOME}/less/history\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport LESSHISTFILE=\"${XDG_CACHE_HOME}\"/less/history\n```\n"
         }
     ]
 }

--- a/programs/npm.json
+++ b/programs/npm.json
@@ -8,7 +8,7 @@
         {
             "path": "$HOME/.npmrc",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport NPM_CONFIG_USERCONFIG=$XDG_CONFIG_HOME/npm/npmrc \n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport NPM_CONFIG_USERCONFIG=\"$XDG_CONFIG_HOME\"/npm/npmrc \n```\n"
         }
     ],
     "name": "npm"

--- a/programs/pex.json
+++ b/programs/pex.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.pex",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport PEX_ROOT=${XDG_CACHE_HOME}/pex\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport PEX_ROOT=\"${XDG_CACHE_HOME}\"/pex\n```\n"
         }
     ]
 }

--- a/programs/pyenv.json
+++ b/programs/pyenv.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.pyenv",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport PYENV_ROOT=$XDG_DATA_HOME/pyenv \n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport PYENV_ROOT=\"$XDG_DATA_HOME\"/pyenv \n```\n"
         }
     ],
     "name": "pyenv"

--- a/programs/pylint.json
+++ b/programs/pylint.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.pylint.d",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport PYLINTHOME=${XDG_CACHE_HOME}/pylint\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport PYLINTHOME=\"${XDG_CACHE_HOME}\"/pylint\n```\n"
         }
     ]
 }

--- a/programs/python-azure-cliAU.json
+++ b/programs/python-azure-cliAU.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.azure",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport AZURE_CONFIG_DIR=$XDG_DATA_HOME/azure \n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport AZURE_CONFIG_DIR=\"$XDG_DATA_HOME\"/azure \n```\n"
         }
     ],
     "name": "python-azure-cliAU"

--- a/programs/ruby-travis.json
+++ b/programs/ruby-travis.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.travis",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport TRAVIS_CONFIG_PATH=$XDG_CONFIG_HOME/travis\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport TRAVIS_CONFIG_PATH=\"$XDG_CONFIG_HOME\"/travis\n```\n"
         }
     ],
     "name": "ruby-travis"

--- a/programs/sqlite.json
+++ b/programs/sqlite.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.sqlite_history",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport SQLITE_HISTORY=$XDG_CACHE_HOME/sqlite_history\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport SQLITE_HISTORY=\"$XDG_CACHE_HOME\"/sqlite_history\n```\n"
         }
     ],
     "name": "sqlite"

--- a/programs/texmacs.json
+++ b/programs/texmacs.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.TeXmacs",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport TEXMACS_HOME_PATH=$XDG_STATE_HOME/texmacs\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport TEXMACS_HOME_PATH=\"$XDG_STATE_HOME\"/texmacs\n```\n"
         }
     ],
     "name": "texmacs"

--- a/programs/texmf.json
+++ b/programs/texmf.json
@@ -3,17 +3,17 @@
         {
             "path": "$HOME/.texlive/texmf-config",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport TEXMFCONFIG=$XDG_CONFIG_HOME/texlive/texmf-config\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport TEXMFCONFIG=\"$XDG_CONFIG_HOME\"/texlive/texmf-config\n```\n"
         },
         {
             "path": "$HOME/.texlive/texmf-var",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport TEXMFVAR=$XDG_CACHE_HOME/texlive/texmf-var\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport TEXMFVAR=\"$XDG_CACHE_HOME\"/texlive/texmf-var\n```\n"
         },
         {
             "path": "$HOME/.texmf",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport TEXMFHOME=$XDG_DATA_HOME/texmf\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport TEXMFHOME=\"$XDG_DATA_HOME\"/texmf\n```\n"
         }
     ],
     "name": "texmf"

--- a/programs/weechat.json
+++ b/programs/weechat.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.weechat",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport WEECHAT_HOME=${XDG_CONFIG_HOME}/weechat\n```\nAlias weechat to use custom locations:\n\n```bash\nalias weechat=weechat -d ${XDG_CONFIG_HOME}/weechat```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport WEECHAT_HOME=\"${XDG_CONFIG_HOME}\"/weechat\n```\nAlias weechat to use custom locations:\n\n```bash\nalias weechat=weechat -d ${XDG_CONFIG_HOME}/weechat```\n"
         }
     ]
 }

--- a/programs/xcompose.json
+++ b/programs/xcompose.json
@@ -4,12 +4,12 @@
         {
             "path": "${HOME}/.XCompose",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport XCOMPOSEFILE=${XDG_CONFIG_HOME}/X11/xcompose\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport XCOMPOSEFILE=\"${XDG_CONFIG_HOME}\"/X11/xcompose\n```\n"
         },
         {
             "path": "${HOME}/.compose-cache",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport XCOMPOSECACHE=${XDG_CACHE_HOME}/X11/xcompose\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport XCOMPOSECACHE=\"${XDG_CACHE_HOME}\"/X11/xcompose\n```\n"
         }
     ]
 }


### PR DESCRIPTION
This prevents globbing and word splitting.
Reference: https://github.com/koalaman/shellcheck/wiki/SC2086

I thought it was best to adjust it here, in case people copy-paste the suggestion given by `xdg-ninja` verbatim in their config.