### PR TITLE
Remove quotes escaping for JULIA_DEPOT_PATH

### DIFF
--- a/programs/julia.json
+++ b/programs/julia.json
@@ -4,7 +4,7 @@
         {
             "path": "$HOME/.julia",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport JULIA_DEPOT_PATH=\\\"$XDG_DATA_HOME/julia:$JULIA_DEPOT_PATH\\\"\n```\n_Note: the trailing **:$JULIA_DEPOT_PATH** is necessary._\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport JULIA_DEPOT_PATH=\"$XDG_DATA_HOME/julia:$JULIA_DEPOT_PATH\"\n```\n_Note: the trailing **:$JULIA_DEPOT_PATH** is necessary._\n"
         }
     ]
 }


### PR DESCRIPTION
Fix an incorrect quote escaping in the recommended `JULIA_DEPOT_PATH` value.

It now can be copied verbatim; following the recommendation at:
https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_DEPOT_PATH