### PR TITLE
Use test for "$MOVABLE" in check_file function

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -157,7 +157,7 @@ check_file() {
         ;;
 
     1)
-        if "$MOVABLE"; then
+        if [ "$MOVABLE" ]; then
             log ERR "$NAME" "$FILENAME" "$HELP"
         else
             log WARN "$NAME" "$FILENAME" "$HELP"


### PR DESCRIPTION
To avoid executing it's value
Patch similar to one in #63