### PR TITLE
Update cabal and opam description

### DIFF
--- a/programs/cabal.json
+++ b/programs/cabal.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.cabal",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport CABAL_CONFIG=\"$XDG_CONFIG_HOME\"/cabal/config\nexport CABAL_DIR=\"$XDG_CACHE_HOME\"/cabal\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport CABAL_CONFIG=\"$XDG_CONFIG_HOME\"/cabal/config\nexport CABAL_DIR=\"$XDG_DATA_HOME\"/cabal\n```\n"
         }
     ],
     "name": "cabal"

--- a/programs/opam.json
+++ b/programs/opam.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.opam",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport OPAMROOT=\"$XDG_DATA_HOME/opam\" \n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport OPAMROOT=\"$XDG_DATA_HOME/opam\" \n```\nRun ```opam init``` to re-initialize it and check the results with ```opam env -v```."
         }
     ],
     "name": "opam"


### PR DESCRIPTION
The cabal help advises to move `CABAL_DIR` to XDG_CACHE_HOME. I think it should point to XDG_DATA_HOME as that dir includes the installed binaries and they represent data, not a cache in my mind.

This PR also expands the opam help as I had some problems with getting it to work. Although I haven't tested that these instructions alone are enough, they should help people diagnose their own problems and lookup help online.