### PR TITLE
Added name to zoom.json

### DIFF
--- a/programs/zoom.json
+++ b/programs/zoom.json
@@ -1,4 +1,5 @@
 {
+	"name": "zoom",
 	"files": [
 		{
 			"path": "$HOME/.zoom",


### PR DESCRIPTION
`zoom.json` was missing the `name` attribute, which caused "[null]" to show up as a name in the terminal. This PR fixes that.