### PR TITLE
Make bat a function that runs batcat if it exists

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -5,6 +5,11 @@ has_command() {
     return $?
 }
 
+# Special Handling for Debian-based Distros
+if has_command batcat; then
+	bat() { batcat "$@"; }
+fi
+
 USE_GLOW=false
 USE_BAT=false
 USE_PYGMENTIZE=false


### PR DESCRIPTION
On Debian and Ubuntu the `bat` binary is renamed to `batcat` to
avoid a name clash with the `bacula` package.

See: https://github.com/sharkdp/bat/issues/982

If `batcat` is present, it is almost certainly what should be used.

Unintentionally invoking bacula with likely invalid arguments is almost certainly *not* intended behavior. This should help with Debian, Ubuntu, Linux Mint, and other derivatives.

To solve this, this shell function named `bat` overrides the native `bat` command from `$PATH` with `batcat` if `batcat` is a valid command.