### PR TITLE
XCURSOR_PATH should be set for custom cursors

### DIFF
--- a/programs/icons.json
+++ b/programs/icons.json
@@ -4,7 +4,7 @@
         {
             "path": "${HOME}/.icons",
             "movable": true,
-            "help": "Supported\n\nThe file ${HOME}/.icons can be moved to ${XDG_DATA_HOME}/icons.\n"
+            "help": "Supported\n\nThe file ${HOME}/.icons can be moved to ${XDG_DATA_HOME}/icons.\n\nIf there are cursor themes installed in _${XDG_DATA_HOME}/icons_, it may be necessary to add the path to XCURSOR_PATH. For example:\n\n```bash\nexport XCURSOR_PATH=/usr/share/icons:${XDG_DATA_HOME}/icons\n```\n\n"
         }
     ]
 }


### PR DESCRIPTION
Added an export instruction for cursor themes installed in ${XDG_DATA_HOME}/icons

If the user has a custom cursor theme installed there may be problems moving $HOME/.icons to $XDG_DATA_HOME/icons if the path is not in XCURSOR_PATH. More info in the [ArchWiki](https://wiki.archlinux.org/title/Cursor_themes#Environment_variable).