### PR TITLE
Fix asdf messages

### DIFF
--- a/programs/asdf-vm.json
+++ b/programs/asdf-vm.json
@@ -3,12 +3,12 @@
         {
             "path": "$HOME/.asdf",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport ASDF_DATA_DIR=\"${XDG_DATA_HOME}\"/asdf\"\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport ASDF_DATA_DIR=\"${XDG_DATA_HOME}\"/asdf\n```\n"
         },
         {
             "path": "$HOME/.asdfrc",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport ASDF_CONFIG_FILE=\"${XDG_CONFIG_HOME}/asdf/asdfrc\"\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport ASDF_CONFIG_FILE=\"${XDG_CONFIG_HOME}\"/asdf/asdfrc\n```\n"
         }
     ],
     "name": "asdf-vm"


### PR DESCRIPTION
Changes
- Remove double quote from end of sentence.
- Add double quote to ASDF_CONFIG_FILE message

Before
```bash
export ASDF_DATA_DIR="${XDG_DATA_HOME}"/asdf"

export ASDF_CONFIG_FILE="${XDG_CONFIG_HOME}/asdf/asdfrc"
```

After
```bash
export ASDF_DATA_DIR="${XDG_DATA_HOME}"/asdf

export ASDF_CONFIG_FILE="${XDG_CONFIG_HOME}"/asdf/asdfrc
```