### PR TITLE
Add anthy

### DIFF
--- a/programs/anthy.json
+++ b/programs/anthy.json
@@ -1,0 +1,10 @@
+{
+  "files": [
+        {
+            "path": "$HOME/.anthy",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://osdn.net/ticket/browse.php?group_id=14&tid=28397\n"
+        }
+    ],
+    "name": "anthy"
+}


### PR DESCRIPTION
Add support for the program [Anthy](https://osdn.net/projects/anthy/), which has the `$HOME/.anthy` path hardcodded :/
Source: https://wiki.archlinux.org/title/XDG_Base_Directory