### PR TITLE
Added mutt-wizard isync environment variable

### DIFF
--- a/programs/isync.json
+++ b/programs/isync.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.mbsyncrc",
             "movable": true,
-            "help": "Alias mbsync to use a custom configuration file location:\n\n```bash\nalias mbsync=mbsync -c \"$XDG_CONFIG_HOME\"/isync/mbsyncrc\n```\n"
+            "help": "Alias mbsync to use a custom configuration file location:\n\n```bash\nalias mbsync=mbsync -c \"$XDG_CONFIG_HOME\"/isync/mbsyncrc\n```\nIf you are using mutt-wizard export the following environment variable:\n\n```bash\nexport MBSYNCRC=\"$XDG_CONFIG_HOME\"/isync/mbsyncrc\n```"
         }
     ],
     "name": "isync"


### PR DESCRIPTION
Added environment variable for isync in the case it is used by [mutt-wizard](https://github.com/LukeSmithxyz/mutt-wizard)
The name of the envirorment varible is hardcoded in the [mw](https://github.com/LukeSmithxyz/mutt-wizard/blob/master/bin/mw) file