### PR TITLE
Fix .cargo file to be movable

### DIFF
--- a/programs/cargo.json
+++ b/programs/cargo.json
@@ -2,7 +2,7 @@
     "files": [
         {
             "path": "$HOME/.cargo",
-            "movable": false,
+            "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport CARGO_HOME=\"$XDG_DATA_HOME\"/cargo\n```\n"
         }
     ],


### PR DESCRIPTION
Idk why cargo's `movable` is set to false [here](https://github.com/b3nj5m1n/xdg-ninja/commit/0ed6693f66fb949929b6d59b1b79dc87be538d61) with `help` saying it's movable. 
Works for me.