### PR TITLE
rofi's .rofi.pid

### DIFF
--- a/programs/rofi.json
+++ b/programs/rofi.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "help": "This file is created when _/run/user/1000_ is inaccesible. Consider fixing this. As a workaround, one can alias rofi to use a pidfile that is not in $HOME but is not in $XDG_RUNTIME_DIR either:\n\n```bash\nalias rofi=\"rofi -pid $XDG_STATE_DIR/rofi\"\n```\n",
+            "movable": true,
+            "path": "$HOME/.rofi.pid"
+        }
+    ],
+    "name": "rofi"
+}

--- a/programs/rofi.json
+++ b/programs/rofi.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "help": "This file is created when _/run/user/1000_ is inaccesible, which usually only happens on non-systemd systems. To fix this, do the following:\n\n**a)**\n\nCheck if _/run/user_ exists.\nIf it does not, skip to part **b)**.\n\nAdd the following to your login shell's login file (_.zlogin_ for zsh, _.bash_login_ for bash):\n```bash\nif test -z \"${XDG_RUNTIME_DIR}\"; then\n    export XDG_RUNTIME_DIR=\"/run/user/${UID}\"\n    if ! test -d \"$XDG_RUNTIME_DIR}\"; then\n        mkdir \"$XDG_RUNTIME_DIR}\"\n        chmod 0700 \"${XDG_RUNTIME_DIR}\"\n    fi\nfi\n```\n\n**b)**\n\n**The following is OpenRC specific**, but one can still implement this fix if they are to translate the given directory and filename to the appropriate rc directory in their init system, the contents should be the same.\n\nCreate the file _/etc/local.d/runuser.start_ and put the following content into it:\n```bash\n#!/bin/sh\nmkdir -p /run/user/1000\nchown YOUR_USERNAME_HERE:users /run/user/1000\nchmod 0700 /run/user/1000\n```\n\nAfter this, make the file executable with:\n```bash\nchmod +x /etc/local.d/runuser.start\n```\n\n**or,**\n\nAs a workaround, one can alias rofi to use a pidfile that is not $HOME but is not $XDG_RUNTIME_DIR either:\n\n```bash\nalias rofi=\"rofi -pid $XDG_STATE_DIR/rofi\"\n```\n",
+            "help": "This file is created when _/run/user/1000_ is inaccesible. Consider fixing this. As a workaround, one can alias rofi to use a pidfile that is not in $HOME but is not in $XDG_RUNTIME_DIR either:\n\n```bash\nalias rofi=\"rofi -pid $XDG_STATE_DIR/rofi\"\n```\n",
             "movable": true,
             "path": "$HOME/.rofi.pid"
         }

--- a/programs/rofi.json
+++ b/programs/rofi.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "help": "This file is created when _/run/user/1000_ is inaccesible. Consider fixing this. As a workaround, one can alias rofi to use a pidfile that is not in $HOME but is not in $XDG_RUNTIME_DIR either:\n\n```bash\nalias rofi=\"rofi -pid $XDG_STATE_DIR/rofi\"\n```\n",
+            "help": "This file is created when _/run/user/1000_ is inaccesible, which usually only happens on non-systemd systems. To fix this, do the following:\n\n**a)**\n\nCheck if _/run/user_ exists.\nIf it does not, skip to part **b)**.\n\nAdd the following to your login shell's login file (_.zlogin_ for zsh, _.bash_login_ for bash):\n```bash\nif test -z \"${XDG_RUNTIME_DIR}\"; then\n    export XDG_RUNTIME_DIR=\"/run/user/${UID}\"\n    if ! test -d \"$XDG_RUNTIME_DIR}\"; then\n        mkdir \"$XDG_RUNTIME_DIR}\"\n        chmod 0700 \"${XDG_RUNTIME_DIR}\"\n    fi\nfi\n```\n\n**b)**\n\n**The following is OpenRC specific**, but one can still implement this fix if they are to translate the given directory and filename to the appropriate rc directory in their init system, the contents should be the same.\n\nCreate the file _/etc/local.d/runuser.start_ and put the following content into it:\n```bash\n#!/bin/sh\nmkdir -p /run/user/1000\nchown YOUR_USERNAME_HERE:users /run/user/1000\nchmod 0700 /run/user/1000\n```\n\nAfter this, make the file executable with:\n```bash\nchmod +x /etc/local.d/runuser.start\n```\n\n**or,**\n\nAs a workaround, one can alias rofi to use a pidfile that is not $HOME but is not $XDG_RUNTIME_DIR either:\n\n```bash\nalias rofi=\"rofi -pid $XDG_STATE_DIR/rofi\"\n```\n",
             "movable": true,
             "path": "$HOME/.rofi.pid"
         }


### PR DESCRIPTION
Cleaning up the last repo seems to have closed the other pull request we were chatting in. This is the renewed version. I don't know how to format my two proposals, I would have normally done them as branches but github only allows a single branch per pull request so I'm guessing we'll figure something out after a decision has been made regarding what solution to go for (like opening a new pull request with only a single commit)

My last message was:
Looking at rofi's source code, one can see that this file is created if the usual one cannot be created at `/run/user/1000`:
https://github.com/davatorium/rofi/blob/next/source/rofi.c#L892
Thus, two solutions arise:
1. just provide users with the workaround
2. teach people how to fix their problems with `/run/user/1000`

The commit titled "Init system agnostic solution" tries to do the first, as the problem relates to what init system one uses. This, obviously, brings maintainability concerns with it:
- If we support x init system's solution, will we have to also include y, z and t init system? Do we have a list of init systems we provide solutions for (the ones we support)? 
- Should a piece of software concerning xdg specification compliance even delve into that?

The commit titled "OpenRC solution" attemps to go the second route and provide the solution for OpenRC, seeing as it's the second most popular init system and the one I'm personally able to use. The reason I exclude systemd is that this highly unlikely to happen on it, maybe unless one messes up a config at a very deep level. This is because systemd ships with logind, which takes care of this and OpenRC does not, one has to either use elogind or deal with it themselves.

Markdown obviously open to change, I just did it the way I considered readable, seeing as the project does not seem to enforce guidelines on this.