### PR TITLE
fix various typos in rules, documentation and program

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ Now, we can assemble our final json file:
 
 Saving this as _git.json_ in the _programs/_ directory will result in the script picking it up and checking the file.
 
-If you've created a configuration for a file that isn't in the offical repository yet, make sure to create a pull request so that other people can benefit from it as well.
+If you've created a configuration for a file that isn't in the official repository yet, make sure to create a pull request so that other people can benefit from it as well.

--- a/lib/AddProgram.hs
+++ b/lib/AddProgram.hs
@@ -78,7 +78,7 @@ getProgram = do
           >> getProp (yellow "Program name: ") ""
   files <- printf "%s\n" (T.unpack (faint (italic (cyan "Alright, now let's configure which files belong to this program."))))
            >> printf "%s\n" (T.unpack (faint (italic (cyan "I'm going to ask you for the path to the file, please use $HOME instead of ~."))))
-           >> printf "%s\n" (T.unpack (faint (italic (cyan "I'll then ask you wether or not this file can be moved to a different directory."))))
+           >> printf "%s\n" (T.unpack (faint (italic (cyan "I'll then ask you whether or not this file can be moved to a different directory."))))
            >> printf "%s\n" (T.unpack (faint (italic (cyan "Finally, your editor is going to open a markdown document. Enter instructions on moving the file in question, then save and close."))))
            >> getFiles []
   return Program {name = T.pack name, files = files}

--- a/lib/Prompts.hs
+++ b/lib/Prompts.hs
@@ -24,8 +24,8 @@ getInputMarkdown placeholder = do
 getProp :: T.Text -> T.Text -> IO String
 getProp prompt placeholder = do
   let string_prompt = T.unpack prompt
-  let string_placholder = T.unpack placeholder
-  x <- runInputT defaultSettings (getInputLineWithInitial string_prompt (string_placholder, ""))
+  let string_placeholder = T.unpack placeholder
+  x <- runInputT defaultSettings (getInputLineWithInitial string_prompt (string_placeholder, ""))
   case x of
     Just s  -> return s
     Nothing -> return ""

--- a/programs/bm.json
+++ b/programs/bm.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "help": "Currently unsupported. Harcoded value.\n",
+            "help": "Currently unsupported. Hardcoded value.\n",
             "movable": false,
             "path": "$HOME/.sdirs"
         }

--- a/programs/dosbox.json
+++ b/programs/dosbox.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.dosbox",
             "movable": true,
-            "help": "Alias dosbox to use a custom configuration locaion:\n\n```bash\nalias dosbox=dosbox -conf \"$XDG_CONFIG_HOME\"/dosbox/dosbox.conf\n```\n\n_Move $HOME/.dosbox/dosbox-0.74-2.conf to $XDG_CONFIG_HOME/dosbox/dosbox.conf._\n"
+            "help": "Alias dosbox to use a custom configuration location:\n\n```bash\nalias dosbox=dosbox -conf \"$XDG_CONFIG_HOME\"/dosbox/dosbox.conf\n```\n\n_Move $HOME/.dosbox/dosbox-0.74-2.conf to $XDG_CONFIG_HOME/dosbox/dosbox.conf._\n"
         }
     ],
     "name": "dosbox"

--- a/programs/gdb.json
+++ b/programs/gdb.json
@@ -9,7 +9,7 @@
         {
             "path": "$HOME/.gdb_history",
             "movable": true,
-            "help": "GDB supports setting it's config file path through an environment variable. Simply move your _.gdb_history_ file to _XDG_CONFIG_HOME/gdb_ and export the follwing:\n\n```bash\nexport GDBHISTFILE=\"$XDG_CONFIG_HOME\"/gdb/.gdb_history \n```\n\nNote: If you are using GEF this does not work, as GEF overwrites the filepath. In order to use the correct path again, you have to call ```set history filename ~/.config/gdb/.gdb_history``` after you source _gef.py_ in your gdb init file.\n"
+            "help": "GDB supports setting it's config file path through an environment variable. Simply move your _.gdb_history_ file to _XDG_CONFIG_HOME/gdb_ and export the following:\n\n```bash\nexport GDBHISTFILE=\"$XDG_CONFIG_HOME\"/gdb/.gdb_history \n```\n\nNote: If you are using GEF this does not work, as GEF overwrites the filepath. In order to use the correct path again, you have to call ```set history filename ~/.config/gdb/.gdb_history``` after you source _gef.py_ in your gdb init file.\n"
         }
     ]
 }

--- a/programs/gef.json
+++ b/programs/gef.json
@@ -4,7 +4,7 @@
         {
             "path": "$HOME/.gef.rc",
             "movable": true,
-            "help": "GEF supports setting it's config file path through an environment variable. Simply move your _.gef.rc_ file to _XDG_CONFIG_HOME/gef_ and export the follwing:\n\n```bash\nexport GEF_RC=\"$XDG_CONFIG_HOME\"/gef/.gef.rc \n```\n"
+            "help": "GEF supports setting it's config file path through an environment variable. Simply move your _.gef.rc_ file to _XDG_CONFIG_HOME/gef_ and export the following:\n\n```bash\nexport GEF_RC=\"$XDG_CONFIG_HOME\"/gef/.gef.rc \n```\n"
         }
     ]
 }

--- a/programs/virtualbox.json
+++ b/programs/virtualbox.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "help": "Supported since _4.3_.\n\nYou can move the file to _XDG_DATA_HOME/virtualbox_.\n\nGo in the settings of the GUI and change the default location.\n\nBe carefull, that might break existing images and changing the path to their respective files is not straight forward.\n",
+            "help": "Supported since _4.3_.\n\nYou can move the file to _XDG_DATA_HOME/virtualbox_.\n\nGo in the settings of the GUI and change the default location.\n\nBe careful, that might break existing images and changing the path to their respective files is not straight forward.\n",
             "movable": true,
             "path": "$HOME/.VirtualBox"
         }

--- a/programs/xscreensaver.json
+++ b/programs/xscreensaver.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "help": "Currently unsupported. Not enought information.\n",
+            "help": "Currently unsupported. Not enough information.\n",
             "movable": false,
             "path": "$HOME/.xscreensaver"
         }


### PR DESCRIPTION
I simply ran the following tools on your code, then fixed the errors reported

- codespell https://github.com/codespell-project/codespell
- typos https://github.com/crate-ci/typos