### PR TITLE
add support for azure-devops

### DIFF
--- a/programs/azure-devops.json
+++ b/programs/azure-devops.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.azure-devops",
+            "movable": true,
+            "help": "Export the following environment variables:\n\n```bash\nexport AZURE_DEVOPS_CACHE_DIR=\"$XDG_CACHE_HOME\"/azure-devops \n```\n"
+        }
+    ],
+    "name": "azure-devops"
+}


### PR DESCRIPTION
- azure-cli defaults to placing its azure-devops cache into
  '$HOME/.azure-devops' unless the environment variable
  'AZURE_DEVOPS_CACHE_DIR' is set.
- azure-devops.json checks for the '~/.azure-devops' directory and
  suggests exporting `AZURE_DEVOPS_CACHE_DIR` as
  '"$XDG_CACHE_HOME"/azure-devops'.