### PR TITLE
add an unsupported status for gitmoji-cli

### DIFF
--- a/programs/gitmoji-cli.json
+++ b/programs/gitmoji-cli.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.gitmoji/gitmojis.json",
+            "movable": false,
+            "help": "Currently unsupported\n\n_Relevant issue:_ https://github.com/carloscuesta/gitmoji-cli/issues/893\n"
+        }
+    ],
+    "name": "gitmoji-cli"
+}


### PR DESCRIPTION
Here is the tool https://github.com/carloscuesta/gitmoji-cli

and the current status https://github.com/carloscuesta/gitmoji-cli/issues/893