### PR TITLE
Add cinnamon and add json schema for program.json

### DIFF
--- a/program-schema/file.json
+++ b/program-schema/file.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "File schema",
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "Path to file (or folder).",
+            "minLength": 1
+        },
+        "movable": {
+            "type": "boolean",
+            "description": "Is file (or folder) movable to a place other than $HOME."
+        },
+        "help": {
+            "type": "string",
+            "description": "Help text for user. Supports markdown."
+        }
+    },
+    "required": [
+        "path",
+        "movable",
+        "help"
+    ]
+}

--- a/program-schema/program.json
+++ b/program-schema/program.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Program",
+    "description": "Specification of files or folders in the $HOME folder for a program",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the program",
+            "minLength": 1
+        },
+        "files": {
+            "description": "List of files (or folders) associated with the program",
+            "type": "array",
+            "items": {
+                "$ref": "file.json"
+            },
+            "minItems": 1
+        }
+    },
+    "required": [
+        "name",
+        "files"
+    ]
+}

--- a/programs/cinnamon.json
+++ b/programs/cinnamon.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "../program-schema/program.json",
+    "name": "cinnamon",
+    "files": [
+        {
+            "path": "$HOME/.cinnamon/spices.cache/",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can either delete or move the folder to _XDG_CONFIG_HOME/cinnamon/spices_.\n"
+        },
+        {
+            "path": "$HOME/.cinnamon/panel-launchers/",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can move the folder to _XDG_DATA_HOME/cinnamon/panel-launchers_.\n"
+        },
+        {
+            "path": "$HOME/.cinnamon/backgrounds/",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can move the folder to _XDG_DATA_HOME/cinnamon/backgrounds_.\n"
+        },
+        {
+            "path": "$HOME/.cinnamon/configs/",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can move the folder to _XDG_CONFIG_HOME/cinnamon/spices_.\n"
+        },
+        {
+            "path": "$HOME/.themes/",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can move the folder to _XGD_DATA_HOME/themes_.\n"
+        },
+        {
+            "path": "$HOME/.icons/",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can move the folder to _XDG_DATA_HOME/icons_.\n"
+        },
+        {
+            "path": "$HOME/.cinnamon/glass.log",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can either delete or move the file to _XDG_STATE_HOME/cinnamon/glass.log_.\n"
+        },
+        {
+            "path": "$HOME/.cinnamon/harvester.log",
+            "movable": true,
+            "help": "Supported since _5.6.0_.\n\nYou can either delete or move the file to _XDG_STATE_HOME/cinnamon/harvester.log_.\n"
+        }
+    ]
+}


### PR DESCRIPTION
The schema can help to validate `.json` files in the `programs` folder (either by using a validator or just using it in an editor that supports it). Helpful for people who just wants to write the json file directly and not use the tool.

Also fixes #194 

PS.: I know I should have split this to 2 PRs but it's late and I'm lazy (also it's not a lot)