### PR TITLE
Updated support of audacity

### DIFF
--- a/programs/audacity.json
+++ b/programs/audacity.json
@@ -2,8 +2,8 @@
     "files": [
         {
             "path": "$HOME/.audacity-data",
-            "movable": false,
-            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/audacity/audacity/issues/453\n"
+            "movable": true,
+            "help": "Supported since version 3.2.0\nYou can move these files.\n"
         }
     ],
     "name": "audacity"


### PR DESCRIPTION
Audacity follows XDG spec since version 3.2.0 unless the folder already exists in the old location.
See audacity/audacity#3088