### PR TITLE
Add lens

### DIFF
--- a/programs/lens.json
+++ b/programs/lens.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/lensapp/lens/issues/2494\n",
+            "movable": false,
+            "path": "$HOME/.k8slens"
+        }
+    ],
+    "name": "lens"
+}


### PR DESCRIPTION
Lens seems to use some xdg directories for parts of it, but not for its extensions directory.
Relevant Issue: https://github.com/lensapp/lens/issues/2494