### PR TITLE
`~/.gitignore` can be moved to `XDG_CONFIG_HOME/git/ignore`

### DIFF
--- a/programs/git.json
+++ b/programs/git.json
@@ -7,6 +7,11 @@
             "help": "XDG is supported out-of-the-box, so we can simply move the file to _XDG_CONFIG_HOME/git/config_.\n"
         },
         {
+            "path": "$HOME/.gitignore",
+            "movable": true,
+            "help": "XDG is supported out-of-the-box, so we can simply move the file to _XDG_CONFIG_HOME/git/ignore_.\n"
+        },
+        {
             "path": "$HOME/.git-credentials",
             "movable": true,
             "help": "XDG is supported out-of-the-box, so we can simply move the file to _XDG_CONFIG_HOME/git/credentials_.\n"


### PR DESCRIPTION
https://git-scm.com/docs/gitignore indicates it will read ignore configuration from `$XDG_CONFIG_HOME/git/ignore`.