### PR TITLE
`~/.fonts.conf` can be moved to `$XDG_CONFIG_HOME/fontconfig/fonts.conf`

### DIFF
--- a/programs/fontconfig.json
+++ b/programs/fontconfig.json
@@ -5,6 +5,11 @@
             "path": "${HOME}/.fontconfig",
             "movable": true,
             "help": "Supported\n\nThe file ${HOME}/.fontconfig can be moved to ${XDG_DATA_HOME}/fontconfig.\n"
+        },
+        {
+            "path": "${HOME}/.fonts.conf",
+            "movable": true,
+            "help": "Supported\n\nThe file ${HOME}/.fonts.conf can be moved to ${XDG_DATA_HOME}/fontconfig/fonts.conf.\n"
         }
     ]
 }


### PR DESCRIPTION
https://www.freedesktop.org/software/fontconfig/fontconfig-user.html states that `~/.fonts.conf` can be placed in several different locations, most notably `$XDG_CONFIG_HOME/fontconfig/fonts.conf`. This pull request adds that recommendation.

Thanks