### PR TITLE
keychain: add `--absolute` opt to avoid subdirectory

### DIFF
--- a/programs/keychain.json
+++ b/programs/keychain.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.keychain",
             "movable": true,
-            "help": "Alias keychain to use a custom runtime dir location:\n\n```bash\nkeychain --dir \"$XDG_RUNTIME_DIR\"/keychain\n```\n"
+            "help": "Alias keychain to use a custom runtime dir location:\n\n```bash\nkeychain --dir \"$XDG_RUNTIME_DIR\"/keychain --absolute\n```\n"
         }
     ],
     "name": "keychain"


### PR DESCRIPTION
## Description

This PR adds `--absolute` to the command provided in the keychain migration instructions.

## Motivation

For backwards compatibility, if the user provides a path `--dir` to keychain, it will create a `.keychain` folder in that path. Adding the [`--absolute`](https://man.archlinux.org/man/keychain.1#absolute) opt will encourage keychain to use the directory as is.