### PR TITLE
Add configuration for Steam game Tales of Maj'Eyal

### DIFF
--- a/programs/t-engine.json
+++ b/programs/t-engine.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.t-engine",
+            "movable": true,
+            "help": "Add the following to the Steam arguments for Tales of Maj'Eyal 4: ```--home $XDG_DATA_HOME```\nThen, move _$HOME/.t-engine_ to _$XDG_DATA_HOME/.t-engine_\n\n**NOTE**: This flag only changes the location in which the directory is created. The actual directory itself is hardcoded as _.t-engine_, so it will still be hidden by default. There is currently no workaround for this.\n\nAlternatively, use the Flatpak version of Steam as noted in the help for _.steam_"
+        }
+    ],
+    "name": "t-engine"
+}


### PR DESCRIPTION
Describes how to move [TOME4](https://store.steampowered.com/app/259680/Tales_of_MajEyal/) (and any other future T-Engine games) data out of $HOME. In the meantime I've also posted a [bug report on the forum](https://forums.te4.org/viewtopic.php?f=70&t=53863) (which at the time of posting has yet to be approved by moderators so is not publicly visible) and will issue a new pull request accordingly if the issue is addressed.