### PR TITLE
Add `rusherhack` support

### DIFF
--- a/programs/rusherhack.json
+++ b/programs/rusherhack.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.rusherhack",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/RusherDevelopment/rusherhack-issues/issues/1422\n"
+        }
+    ],
+    "name": "rusherhack"
+}


### PR DESCRIPTION
Rusherhack is a Minecraft anarchy mod. It puts the auth files in `~/.rusherhack` by default. This will likely [change](https://github.com/RusherDevelopment/rusherhack-issues/issues/1422) in the future, but for now, this is warranted.