### PR TITLE
add `octave` to darabase

### DIFF
--- a/programs/octave.json
+++ b/programs/octave.json
@@ -9,12 +9,7 @@
             "help": "In $XDG_CONFIG_HOME/octave/octaverc, add the following line:\n\n```\nsource /usr/share/octave/site/m/startup/octaverc;\npkg prefix ~/.local/share/octave/packages ~/.local/share/octave/packages;\npkg local_list /home/<your username>/.local/share/octave/octave_packages;\n```\n\nThe `local_list` option must be given an absolute path.",
             "movable": true,
             "path": "$HOME/.octave_packages"
-        },
-        {
-            "help": "Export the following environment variables:\n\n```bash\nexport OCTAVE_HISTFILE=\"$XDG_CACHE_HOME/octave-hsts\"\n```",
-            "movable": true,
-            "path": "$HOME/.octave_hist"
         }
-    ],
+            ],
     "name": "octave"
 }

--- a/programs/octave.json
+++ b/programs/octave.json
@@ -1,0 +1,20 @@
+{
+    "files": [
+        {
+            "help": "Export the following environment variables:\n\n```bash\nexport OCTAVE_SITE_INITFILE=\"$XDG_CONFIG_HOME/octave/octaverc\"\n```",
+            "movable": true,
+            "path": "$HOME/.octaverc"
+        },
+        {
+            "help": "In $XDG_CONFIG_HOME/octave/octaverc, add the following line:\n\n```\nsource /usr/share/octave/site/m/startup/octaverc;\npkg prefix ~/.local/share/octave/packages ~/.local/share/octave/packages;\npkg local_list /home/<your username>/.local/share/octave/octave_packages;\n```\n\nThe `local_list` option must be given an absolute path.",
+            "movable": true,
+            "path": "$HOME/.octave_packages"
+        },
+        {
+            "help": "Export the following environment variables:\n\n```bash\nexport OCTAVE_HISTFILE=\"$XDG_CACHE_HOME/octave-hsts\"\n```",
+            "movable": true,
+            "path": "$HOME/.octave_hist"
+        }
+    ],
+    "name": "octave"
+}

--- a/programs/octave.json
+++ b/programs/octave.json
@@ -4,11 +4,6 @@
             "help": "Export the following environment variables:\n\n```bash\nexport OCTAVE_SITE_INITFILE=\"$XDG_CONFIG_HOME/octave/octaverc\"\n```",
             "movable": true,
             "path": "$HOME/.octaverc"
-        },
-        {
-            "help": "In $XDG_CONFIG_HOME/octave/octaverc, add the following line:\n\n```\nsource /usr/share/octave/site/m/startup/octaverc;\npkg prefix ~/.local/share/octave/packages ~/.local/share/octave/packages;\npkg local_list /home/<your username>/.local/share/octave/octave_packages;\n```\n\nThe `local_list` option must be given an absolute path.",
-            "movable": true,
-            "path": "$HOME/.octave_packages"
         }
             ],
     "name": "octave"


### PR DESCRIPTION
* octave fully supports XDG for history file and site packages.
* octave partially supports XDG for rc file. An environment variable is needed.