### PR TITLE
Add fzf

### DIFF
--- a/programs/fzf.json
+++ b/programs/fzf.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.fzf",
+            "movable": true,
+            "help": "This has been added since 0.17.4. See https://github.com/junegunn/fzf/pull/1282 .\nReinstall from git with ```bash\n~/.fzf/uninstall\nrm -rf ~/.fzf\ngit clone --depth 1 https://github.com/junegunn/fzf.git $XDG_DATA_HOME/fzf\n$XDG_DATA_HOME/fzf/install --xdg\n```\n"
+        }
+    ],
+    "name": "fzf"
+}


### PR DESCRIPTION
This also affects `~/.fzf.bash` and possibly `~/.fzf.zsh` but those are removed by the uninstall script. I'm unsure whether to list both files separately in the json file.