### PR TITLE
Add VSCode LeetCode Extension

### DIFF
--- a/programs/vscode-leetcode-extension.json
+++ b/programs/vscode-leetcode-extension.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "help": "Currently unsupported.\n\n_Relevant issue:_\nhttps://github.com/LeetCode-OpenSource/vscode-leetcode/issues/873\n",
+            "movable": false,
+            "path": "$HOME/.lc"
+        }
+    ],
+    "name": "VSCode LeetCode Extension"
+}


### PR DESCRIPTION
In VSCode, you can install a LeetCode extension that creates a `$HOME/.lc` directory to store its login cookies/cache. Added link to relevant bug. Included extra newline to avoid link breaking.