### PR TITLE
Add mamba

### DIFF
--- a/programs/mamba.json
+++ b/programs/mamba.json
@@ -1,0 +1,15 @@
+{
+    "files": [
+        {
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/mamba-org/mamba/issues/1787\n",
+            "movable": false,
+            "path": "$HOME/.mambarc"
+        },
+        {
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/mamba-org/mamba/issues/1787\n",
+            "movable": false,
+            "path": "$HOME/.mamba"
+        }
+    ],
+    "name": "mamba"
+}


### PR DESCRIPTION
[Mamba](https://mamba.readthedocs.io/en/latest/index.html) currently does not support XDG, added information to point to the [issue](https://github.com/mamba-org/mamba/issues/1787)