### PR TITLE
Add Paradox Interactive Games

### DIFF
--- a/paradox-games.json
+++ b/paradox-games.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "help": "Currently unsupported. The only _hacky_ way to get rid of it is via a **bubblewrap sandbox**.\n\nRelevant Arch Wiki: https://wiki.archlinux.org/title/Bubblewrap",
+            "movable": false,
+            "path": "$HOME/.paradoxinteractive"
+        }
+    ],
+    "name": "paradox games"
+}


### PR DESCRIPTION
Adds support for the `$HOME/.paradoxinteractive` folder. Created by _(linux native)_ Paradox Interactive games.