### PR TITLE
Add Project Zomboid support

### DIFF
--- a/programs/project-zomboid.json
+++ b/programs/project-zomboid.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "help": "Add the following startup parameters to the game on Steam:\n\n`-cachedir=~/.local/share/Zomboid`",
+            "movable": true,
+            "path": "$HOME/Zomboid"
+        }
+    ],
+    "name": "project zomboid"
+}


### PR DESCRIPTION
Adds support for the Project Zomboid game.

Source: https://theindiestone.com/forums/index.php?/topic/29349-follow-the-xdg-base-directory-specification-on-linux/#comment-294498