### PR TITLE
Unified packaging process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+PREFIX ?= /usr/local
+
+all:
+	@echo "Usage: make (install|uninstall)"
+
+.PHONY: all install uninstall
+
+install:
+	install -Dm 0755 xdg-ninja.sh $(DESTDIR)$(PREFIX)/bin/xdg-ninja
+	install -d $(DESTDIR)$(PREFIX)/share/xdg-ninja/
+	cp -r programs $(DESTDIR)$(PREFIX)/share/xdg-ninja/
+	install -d $(DESTDIR)$(PREFIX)/share/doc/xdg-ninja/
+	install -m 0644 LICENSE README.md $(DESTDIR)$(PREFIX)/share/doc/xdg-ninja/
+
+uninstall:
+	rm -rf $(DESTDIR)$(PREFIX)/bin/xdg-ninja \
+	       $(DESTDIR)$(PREFIX)/share/xdg-ninja \
+	       $(DESTDIR)$(PREFIX)/share/doc/xdg-ninja

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To install xdg-ninja with [Homebrew](https://brew.sh), run `brew install xdg-nin
 
 ## Configuration
 
-The configuration is done in the _programs/_ directory.
+The configuration is done in the _programs/_ directory, which should be located in the same working directory as the xdg-ninja.sh script. This can be overriden with the `XN_PROGRAMS_DIR` environment variable.
 
 You define a program, and then a list of files and directories which this program ruthlessly puts into your _$HOME_ directory.
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,25 @@
       in rec {
         packages = flake-utils.lib.flattenTree {
           # The shell script and configurations, uses derivation from offical nixpkgs
-          xdg-ninja = pkgs.xdg-ninja;
+          xdg-ninja = pkgs.stdenv.mkDerivation rec {
+            pname = "xdg-ninja";
+            version = "0.1.0";
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [ makeWrapper ];
+
+            installPhase = ''
+              runHook preInstall
+
+              DESTDIR="$out" PREFIX="/usr" make install
+
+              wrapProgram "$out/usr/bin/xdg-ninja" \
+                --prefix PATH : "${pkgs.lib.makeBinPath [ pkgs.glow pkgs.jq ]}"
+
+              runHook postInstall
+            '';
+          };
           # Pre-built binary of xdgnj tool downloaded from github
           xdgnj-bin = pkgs.stdenvNoCC.mkDerivation {
             name = "xdgnj-bin";
@@ -45,7 +63,7 @@
         };
         defaultPackage = packages.xdg-ninja;
         apps = {
-          xdg-ninja = flake-utils.lib.mkApp { drv = packages.xdg-ninja; };
+          xdg-ninja = flake-utils.lib.mkApp { drv = packages.xdg-ninja; exePath = "/usr/bin/xdg-ninja"; };
           xdgnj-bin = flake-utils.lib.mkApp { drv = packages.xdgnj-bin; exePath = "/bin/xdgnj"; };
         };
         defaultApp = apps.xdg-ninja;

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -218,7 +218,7 @@ do_check_programs() {
 " read -r name; read -r filename; read -r movable; read -r help; do
         check_file "$name" "$filename" "$movable" "$help"
     done <<EOF
-$(jq 'inputs as $input | $input.files[] as $file | $input.name, $file.path, $file.movable, $file.help' "$(realpath "$0" | xargs dirname)"/programs/* | sed -e 's/^"//' -e 's/"$//')
+$(jq 'inputs as $input | $input.files[] as $file | $input.name, $file.path, $file.movable, $file.help' "$XN_PROGRAMS_DIR"/* | sed -e 's/^"//' -e 's/"$//')
 EOF
 # sed is to trim quotes
 }
@@ -232,6 +232,9 @@ check_programs() {
     printf "%bIf you have files in your %b\$HOME%b that shouldn't be there, but weren't recognised by xdg-ninja, please consider creating a configuration file for it and opening a pull request on github.%b\n" "${FX_ITALIC}" "${FG_CYAN}" "${FX_RESET}${FX_ITALIC}" "${FX_RESET}"
     printf "\n"
 }
+
+[ "$XN_PROGRAMS_DIR" ] ||
+    XN_PROGRAMS_DIR="$(realpath "$0" | xargs dirname | sed 's:/bin$:/share/xdg-ninja:g')/programs"
 
 check_programs
 if [ $FIXABLE -gt 100 ]; then


### PR DESCRIPTION
Hey!

It seems to me that xdg-ninja is packaged quite poorly in some cases, like [putting a symlink to the programs/ directory directly in the bin/ folder of the system](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xdg-ninja) or [modifying the script in place to patch the location of the programs/ directory](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=xdg-ninja-git).

This mostly is a consequence of the way the script currently fetches the `programs/` directory:

https://github.com/b3nj5m1n/xdg-ninja/blob/4644d409aaf00b7d3b6864840f23e4c05c830322/xdg-ninja.sh#L221

i.e., directly in the current working directory of the xdg-ninja script.

This works fine when working within the git repository but does poorly when trying to package the program as there needs to implement hacks to get this working.

_On a useless note, I wouldn't have hacked it this way on my side, I would've just packaged xdg-ninja in the same directory as programs in, for instance, `/usr/share/xdg-ninja/` and would create a wrapper script that would call `/usr/share/xdg-ninja/xdg-ninja.sh`._

I am unsure whether or not this is a goal of your program to be packaged, but if so, I have implemented an simple way to unify the packaging process.

---

My main goal, when modifying the script, was to get it backwards compatible with how it was previously used, i.e. when working in the git repository, it does fetch the current `programs/` dir rather than somewhere else.

So I have just set the script to check in the current working directory and replace ending instances of `/bin` to `/share/xdg-ninja` (where the `programs/` dir is located when packaged).

If all cases it fails, the `XN_PROGRAMS_DIR` can be used to override that value. I have preferred to use this instead of a `--programs-dir=` argument as this isn't something meant for common usage either.

I've also allowed people to override where the script is supposed to be located with the `PREFIX` variable in the `Makefile`, I believe package managers should package apps to `/usr` instead of `/usr/local` so at least it can be changed. This `make` variable and `DESTDIR` and both common naming standards.