### PR TITLE
Makefile does not create man1 directory properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,14 @@ all:
 .PHONY: all install uninstall
 
 install:
-	install -Dm 0755 xdg-ninja.sh $(DESTDIR)$(PREFIX)/bin/xdg-ninja
-	install -d $(DESTDIR)$(PREFIX)/share/xdg-ninja/
-	cp -r programs $(DESTDIR)$(PREFIX)/share/xdg-ninja/
-	install -d $(DESTDIR)$(PREFIX)/share/doc/xdg-ninja/
-	install -m 0644 LICENSE README.md $(DESTDIR)$(PREFIX)/share/doc/xdg-ninja/
-	install -m 0644 man/xdg-ninja.1 $(DESTDIR)$(PREFIX)/share/man/man1/
+	install -Dm 0755 -T xdg-ninja.sh '$(DESTDIR)$(PREFIX)/bin/xdg-ninja'
+	install -d '$(DESTDIR)$(PREFIX)/share/xdg-ninja/'
+	cp -r programs '$(DESTDIR)$(PREFIX)/share/xdg-ninja/'
+	install -Dm 0644 -t '$(DESTDIR)$(PREFIX)/share/doc/xdg-ninja/' LICENSE README.md
+	install -Dm 0644 -t '$(DESTDIR)$(PREFIX)/share/man/man1/' man/xdg-ninja.1
 
 uninstall:
-	rm -rf $(DESTDIR)$(PREFIX)/bin/xdg-ninja \
-	       $(DESTDIR)$(PREFIX)/share/xdg-ninja \
-	       $(DESTDIR)$(PREFIX)/share/doc/xdg-ninja \
-	       $(DESTDIR)$(PREFIX)/share/man/man1/xdg-ninja.1
+	rm -rf '$(DESTDIR)$(PREFIX)/bin/xdg-ninja' \
+	       '$(DESTDIR)$(PREFIX)/share/xdg-ninja' \
+	       '$(DESTDIR)$(PREFIX)/share/doc/xdg-ninja' \
+	       '$(DESTDIR)$(PREFIX)/share/man/man1/xdg-ninja.1'


### PR DESCRIPTION
Since the addition of the man 1, the Makefile doesn't properly ensure that `$(DESTDIR)$(PREFIX)/share/man/man1/` exists, causing an install error if it doesn't exist.