### PR TITLE
Update zsh.json and ohmyzsh.json

### DIFF
--- a/programs/ohmyzsh.json
+++ b/programs/ohmyzsh.json
@@ -4,6 +4,11 @@
             "path": "$HOME/.oh-my-zsh",
             "movable": true,
             "help": "See the relevant [issue](https://github.com/ohmyzsh/ohmyzsh/issues/9543).\n\nExport the following environment variables:\n\n```bash\nexport ZSH=\"$XDG_DATA_HOME\"/oh-my-zsh \n```\n"
+        },
+        {
+            "path": "$HOME/.zshrc.pre-oh-my-zsh",
+            "movable": true,
+            "help": "If it exists, it is used when switching back to the default shell you had before installing Oh My Zsh. See the [FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#how-do-i-uninstall-oh-my-zsh) for more information.\n\nYou can either back it up elsewhere or delete it.\n"
         }
     ],
     "name": "ohmyzsh"

--- a/programs/ohmyzsh.json
+++ b/programs/ohmyzsh.json
@@ -9,6 +9,11 @@
             "path": "$HOME/.zshrc.pre-oh-my-zsh",
             "movable": true,
             "help": "If it exists, it is used when switching back to the default shell you had before installing Oh My Zsh. See the [FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#how-do-i-uninstall-oh-my-zsh) for more information.\n\nYou can either back it up elsewhere or delete it.\n"
+        },
+        {
+            "path": "$HOME/.zshrc.pre-oh-my-zsh-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]-[0-9][0-9]-[0-9][0-9]",
+            "movable": true,
+            "help": "If it exists, it is used when switching back to the default shell you had before installing Oh My Zsh. See the [FAQ](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#how-do-i-uninstall-oh-my-zsh) for more information.\n\nYou can either back it up elsewhere or delete it.\n"
         }
     ],
     "name": "ohmyzsh"

--- a/programs/zsh.json
+++ b/programs/zsh.json
@@ -8,7 +8,7 @@
         {
             "help": "Set this in your zshrc:\n\n```bash\ncompinit -d \"$XDG_CACHE_HOME\"/zsh/zcompdump-\"$ZSH_VERSION\"\n```\n",
             "movable": true,
-            "path": "$HOME/.zcompdump"
+            "path": "$HOME/.zcompdump*"
         },
         {
             "help": "Set this in your zshrc:\n\n```bash\nexport HISTFILE=\"$XDG_STATE_HOME\"/zsh/history\n```\n",


### PR DESCRIPTION
Add support for `.zshrc.pre-oh-my-zsh`, `.zshrc.pre-oh-my-zsh-YYYY-mm-dd_HH-MM-SS`, `.zcompdump-<hostname>-<version>.zwc`, `.zcompdump-<hostname>-<version>` and `.zcompdump-<user>-<version>`.

~~_Note_: due to current limitations, it's not possible to match a slight variation of this path, namely `.zshrc.pre-oh-my-zsh-YYYY-mm-dd_HH-MM-SS`. See #263.~~

This pull request relies on #271.