### PR TITLE
xdg-ninja: add shell pattern matching capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To install xdg-ninja with [Homebrew](https://brew.sh), run `brew install xdg-nin
 
 - your favorite POSIX-compliant shell ([bash](https://repology.org/project/bash/packages), [zsh](https://repology.org/project/zsh/packages), [dash](https://repology.org/project/dash-shell/packages), ...)
 - [jq](https://repology.org/project/jq/packages) for parsing the json files
+- [find](https://repology.org/project/findutils/versions)
 
 ### Optional
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
         runtimeDependencies = with pkgs; [
           glow
           jq
+          findutils
         ];
         overlays = [
           (self: super: {


### PR DESCRIPTION
Relaunching this to spark some discussion about #263.

The implementation wouldn't solve the first point talked about in the issue but would make up for the rest of the issue. I can also take a look at adding capability for multi-files.

I quickly tested it on my side but I'd rather have someone double check this works indeed fine, @Midblyte would you be interested in rebasing your patch on this one to test out #264?

I have also changed the `check_file` behavior to retrieve the file name so that `$HOME/.test-*` would be spelled out with the actual file name if it is fine (e.g., it would print `/home/user/.test-2023`).

Since calls to `find` is quite costy, I have also added a `has_pattern` function to use shell pattern maching in the case the string contains `*`, `?` or `[something]`.