### PR TITLE
Check for interactive terminal and user request for colorless

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -42,7 +42,10 @@ init_constants() {
 
     BG_MAGENTA="\033[45m"
 }
-init_constants
+
+if test -t 0 && test "$TERM" != "dumb" && test "$TERM" != "xterm-mono" && test -n "$NO_COLOR" & test "$LS_COLORS" -gt 0; then
+    init_constants
+fi
 
 help() {
     init_constants


### PR DESCRIPTION
don't initialize color if TERM is dumb, xterm-mono, if NO_COLOR is set, or if LS_COLORS is not 0 (technically this check is for LS_COLORS greater than 0, but i've never seen negative values for it, but if you disapprove of my laziness i can add a greater than -1 test too.)