### PR TITLE
Improve GDB recommendation

### DIFF
--- a/programs/gdb.json
+++ b/programs/gdb.json
@@ -4,7 +4,7 @@
         {
             "path": "$HOME/.gdbinit",
             "movable": true,
-            "help": "Alias gdb to use custom locations:\n\n```bash\nalias gdb=gdb -n -x $XDG_CONFIG_HOME/gdb/init```\n"
+            "help": "XDG is supported out-of-the-box, so you can simply move the file to _$XDG_CONFIG_HOME/gdb/gdbinit_.\n"
         },
         {
             "path": "$HOME/.gdb_history",


### PR DESCRIPTION
The previous suggestion was to use an alias and specify the config path directly, though GDB supports XDG paths according to the man pages.

I don't know what version XDG support was added, or if it has been there all along. I'm currently using GDB version 13.1