### PR TITLE
updated cups, it is now supported by libcups

### DIFF
--- a/programs/cups.json
+++ b/programs/cups.json
@@ -1,10 +1,10 @@
 {
-    "name": "CUPS",
-    "files": [
-        {
-            "path": "$HOME/.cups",
-	    "movable": false,
-	    "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/OpenPrinting/cups/issues/10\n"
-        }
-    ]
+  "name": "CUPS",
+  "files": [
+    {
+      "path": "$HOME/.cups",
+      "movable": true,
+      "help": "Supported.\n\nThe file $HOME/.cups can be moved to $XDG_CONFIG_HOME/cups.\n\n_Relevant issue:_ https://github.com/OpenPrinting/cups/issues/10\n"
+    }
+  ]
 }


### PR DESCRIPTION
The relevant issue that was pointed to previously was solved at the beginning of this year, cups does support the XDG spec now.