### PR TITLE
Add fennel

### DIFF
--- a/programs/fennel.json
+++ b/programs/fennel.json
@@ -1,0 +1,10 @@
+{
+    "name": "fennel",
+    "files": [
+        {
+            "path": "$HOME/.fennelrc",
+            "movable": true,
+            "help": "Supported since _v0.3.1_.\n\nYou can move the file to _$XDG_CONFIG_HOME/fennel/fennelrc_.\n"
+        }
+    ]
+}


### PR DESCRIPTION
Support for detecting `~/.fennelrc`. It can be XDG compliant since [v0.3.1](https://fennel-lang.org/v0.3.1/).