### PR TITLE
Fix skipping one program during check

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -230,7 +230,7 @@ do_check_programs() {
 " read -r name; read -r filename; read -r movable; read -r help; do
         check_file "$name" "$filename" "$movable" "$help"
     done <<EOF
-$(jq 'if type == "object" then .files[] as $file | .name, $file.path, $file.movable, $file.help else . end' programs/* | sed -e 's/^"//' -e 's/"$//')
+$(jq 'if type == "object" then .files[] as $file | .name, $file.path, $file.movable, $file.help else . end' "$XN_PROGRAMS_DIR"/* | sed -e 's/^"//' -e 's/"$//')
 EOF
 # sed is to trim quotes
 }

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -230,7 +230,7 @@ do_check_programs() {
 " read -r name; read -r filename; read -r movable; read -r help; do
         check_file "$name" "$filename" "$movable" "$help"
     done <<EOF
-$(jq 'inputs as $input | $input.files[] as $file | $input.name, $file.path, $file.movable, $file.help' "$XN_PROGRAMS_DIR"/* | sed -e 's/^"//' -e 's/"$//')
+$(jq 'if type == "object" then .files[] as $file | .name, $file.path, $file.movable, $file.help else . end' programs/* | sed -e 's/^"//' -e 's/"$//')
 EOF
 # sed is to trim quotes
 }

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -230,7 +230,7 @@ do_check_programs() {
 " read -r name; read -r filename; read -r movable; read -r help; do
         check_file "$name" "$filename" "$movable" "$help"
     done <<EOF
-$(jq 'if type == "object" then .files[] as $file | .name, $file.path, $file.movable, $file.help else . end' "$XN_PROGRAMS_DIR"/* | sed -e 's/^"//' -e 's/"$//')
+$(jq '.files[] as $file | .name, $file.path, $file.movable, $file.help' "$XN_PROGRAMS_DIR"/* | sed -e 's/^"//' -e 's/"$//')
 EOF
 # sed is to trim quotes
 }


### PR DESCRIPTION
When there's only one file in the `programs/` directory, it does not get picked up by xdg-ninja.

Reproducing:
```bash
git clone git@github.com:b3nj5m1n/xdg-ninja.git && cd xdg-ninja
mv programs/abook.json . && rm programs/* && mv abook.json programs
./xdg-ninja.sh -v
```
This doesn't produce any output for abook.json on the main branch.

Since I found this accidentally during testing #271 and "fixed" it using ChatGPT, I'm not sure if this may introduce other unexpected side effects.