### PR TITLE
Add ngrok

### DIFF
--- a/programs/ngrok.json
+++ b/programs/ngrok.json
@@ -1,0 +1,10 @@
+{
+    "name": "ngrok",
+    "files": [
+        {
+            "path": "$HOME/.ngrok2",
+            "movable": true,
+            "help": "Ngrok v3 uses the XDG spec.\n Update from v2 to v3 and run the following command to automatically relocate your configuration to __XDG_CONFIG_HOME__:\n\n```ngrok config upgrade --relocate```\n\nYou have to manually delete the old folder in your __HOME__ after that."
+        }
+    ]
+}


### PR DESCRIPTION
Ngrok v3 uses the XDG spec.

Source:
https://ngrok.com/docs/guides/upgrade-v2-v3/