### PR TITLE
Add .erlang.cookie

### DIFF
--- a/programs/erlang.json
+++ b/programs/erlang.json
@@ -1,0 +1,10 @@
+{
+  "name": "erlang",
+  "files": [
+    {
+      "path": "$HOME/.erlang.cookie",
+      "movable": true,
+      "help": "Erlang supports the XDG spec, so just move this file to _$XDG_CONFIG_HOME/erlang/.erlang.cookie_.\n\n"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a state file for the [Erlang](https://www.erlang.org/) programming language and virtual machine.