### PR TITLE
Add flyctl

### DIFF
--- a/programs/flyctl.json
+++ b/programs/flyctl.json
@@ -1,0 +1,10 @@
+{
+  "name": "flyctl",
+  "files": [
+    {
+      "path": "$HOME/.fly",
+      "movable": false,
+      "help": "Currently unsupported.\n\n_Merge Request_: https://github.com/superfly/flyctl/pull/2785\n"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the [flyctl](https://github.com/superfly/flyctl) client for fly.io.