### PR TITLE
Add OpenJFX

### DIFF
--- a/programs/openjfx.json
+++ b/programs/openjfx.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "help": "**Disclaimer: some applications don't respect this setting.**\n\nExport the following environment variable:\n\n```bash\nexport _JAVA_OPTIONS=\"-Djava.util.prefs.userRoot=${XDG_CONFIG_HOME}/java -Djavafx.cachedir=${XDG_CACHE_HOME}/openjfx\"\n```\n\n_Relevant pull request:_ https://github.com/javafxports/openjdk-jfx/pull/300\n",
+            "movable": true,
+            "path": "$HOME/.openjfx"
+        }
+    ],
+    "name": "OpenJFX"
+}


### PR DESCRIPTION
[OpenJFX](https://github.com/openjdk/jfx) is the open source version of the JavaFX client application platform (equivalent to OpenJDK for the Java JDK). Programs which use it may create `~/.openjfx` as a cache folder. 

The ArchWiki also says it may create `~/.java/webview` so both the Java `userRoot` and JavaFX `cachedir` options are exported in `_JAVA_OPTIONS`. Users may already have the OpenJDK `userRoot` option set. As per the OpenJDK entry, disclaimer about applications ignoring the option has been added. 