### PR TITLE
Add mtPaint

### DIFF
--- a/programs/mtpaint.json
+++ b/programs/mtpaint.json
@@ -1,0 +1,11 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.mtpaint",
+            "movable": true,
+            "help": "mtPaint supports setting its config file path through a system-wide configuration file.\n\nCreate file `/etc/mtpaint/mtpaintrc` and add the following contents:\n\n```userINI = ~/.config/mtpaint```\n\n*Relevant issue:* https://github.com/wjaguar/mtPaint/issues/22"
+        }
+    ],
+    "name": "mtPaint"
+}
+


### PR DESCRIPTION
mtPaint is a graphics editor for creating icons and pixel art. It automatically creates a config file at `~/.mtpaint`. This shows a workaround using the system configuration file for mtPaint to manually set the user config file location. 

This still doesn't make it XDG compliant as it isn't setting it to an environment variable like `XDG_CONFIG_HOME` but at least gets the file out of the home directory. 