### PR TITLE
mark zoom as not `movable`

### DIFF
--- a/programs/zoom.json
+++ b/programs/zoom.json
@@ -3,7 +3,7 @@
 	"files": [
 		{
 			"path": "$HOME/.zoom",
-			"movable": true,
+			"movable": false,
 			"help": "Unrecommended: setting the following variable moves the contents of .zoom but the directory itself always gets created. Moreover, it breaks some functionalities eg. being able to start a meeting:\n\n```bash\nexport SSB_HOME=\"$XDG_DATA_HOME\"/zoom\n```\n"
 		}
 	]


### PR DESCRIPTION
moving `$HOME/.zoom` and setting `$SSB_HOME` doesn't really do anything since the next run of `zoom` re-creates the `$HOME/.zoom` dir with similar contents
