### PR TITLE
Respect NO_COLOR & co

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -25,22 +25,28 @@ auto_set_decoder() {
         printf "Install glow for easier reading & copy-paste.\n"
     fi
 }
-auto_set_decoder
+if test -t 1 && test "$TERM" != "dumb" && test "$TERM" != "xterm-mono" && test -z "$NO_COLOR"; then
+    auto_set_decoder
+else
+    DECODER="cat"
+fi
 
 unalias -a
 
 init_constants() {
-    FX_RESET="\033[0m"
-    FX_BOLD="\033[1m"
-    FX_ITALIC="\033[3m"
+    if test -t 1 && test "$TERM" != "dumb" && test "$TERM" != "xterm-mono" && test -z "$NO_COLOR"; then
+        FX_RESET="\033[0m"
+        FX_BOLD="\033[1m"
+        FX_ITALIC="\033[3m"
 
-    FG_RED="\033[31m"
-    FG_GREEN="\033[32m"
-    FG_YELLOW="\033[33m"
-    FG_CYAN="\033[36m"
-    FG_WHITE="\033[37m"
+        FG_RED="\033[31m"
+        FG_GREEN="\033[32m"
+        FG_YELLOW="\033[33m"
+        FG_CYAN="\033[36m"
+        FG_WHITE="\033[37m"
 
-    BG_MAGENTA="\033[45m"
+        BG_MAGENTA="\033[45m"
+    fi
 }
 init_constants
 


### PR DESCRIPTION
If `NO_COLOR` is set, or `TERM` is either `dumb` or `xterm-mono`, or the standard output is not on a terminal, do not use colors, nor render markdown (because that'll use colors too).

Based on #282 by @Aeyk: I took their code, fixed up the issues mentioned in review, and also made the same logic apply to `auto_set_decoder` as the original code applied to `init_constants`. `DECODER` will be set to `cat` if any of the no-color conditions apply.

I also moved the checking into `init_constants`, so that `--help` is correctly displayed without colors if `NO_COLOR` is set.

Also updated the checks to test the standard output for being connected to a terminal, rather than standard input.