### PR TITLE
Added PCManFM, updated GIMP

### DIFF
--- a/programs/gimp.json
+++ b/programs/gimp.json
@@ -1,9 +1,9 @@
 {
     "files": [
         {
-            "help": "Currently unsupported.\n\n_Relevant issue:_ https://bugzilla.gnome.org/show_bug.cgi?id=166643\n",
-            "movable": false,
-            "path": "$HOME/.thumbnails"
+            "path": "$HOME/.thumbnails",
+            "movable": true,
+            "help": "Supported\n\nDirectory .thumbnails can be moved to _$XDG_CACHE_HOME/thumbnails_.\nConfiguration dicrectorycan be moved to _$XDG_CONFIG_HOME/GIMP/{GIMP_APP_VERSION}_."
         }
     ],
     "name": "gimp"

--- a/programs/pcmanfm.json
+++ b/programs/pcmanfm.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.thumbnails",
+            "movable": true,
+            "help": "Supported\n\nDirectory .thumbnails can be moved to _$XDG_CACHE_HOME/thumbnails_."
+        }
+    ],
+    "name": "PCManFM"
+}


### PR DESCRIPTION
Note that both PCManFM and GIMP used to store thumbnails in `$HOME/.thumbnails`. So now if the user has that directory, they will get messages for both apps

PCManFM: 
- https://github.com/lxde/libfm/issues/57

GIMP (cache and config):
- https://gitlab.gnome.org/GNOME/gimp/-/commit/483505f
- https://gitlab.gnome.org/GNOME/gimp/-/commit/60e0cfe