### PR TITLE
Fix link for bun

### DIFF
--- a/programs/bun.json
+++ b/programs/bun.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.bun",
             "movable": false,
-            "help": "Currently not supported, see [this issue](https://github.com/oven-sh/bun/issues/696). \n"
+            "help": "Currently not supported, see [this issue](https://github.com/oven-sh/bun/issues/1678) . \n"
         }
     ],
     "name": "bun"


### PR DESCRIPTION
The [linked issue](https://github.com/oven-sh/bun/issues/696) was closed as a duplicate of https://github.com/oven-sh/bun/issues/1678 so i updated the link

i also moved the dot after the link because in (at least my terminal, using konsole and zsh) clicking on the link would take one to .../issues/696. instead of .../issues/696 which didn't work