### PR TITLE
flake: use stdenvNoCC

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         packages = flake-utils.lib.flattenTree rec {
           default = xdg-ninja;
           # The shell script and configurations, uses derivation from offical nixpkgs
-          xdg-ninja = pkgs.stdenv.mkDerivation {
+          xdg-ninja = pkgs.stdenvNoCC.mkDerivation {
             pname = "xdg-ninja";
             version = "0.1.0";
 


### PR DESCRIPTION
Drastically reduces the size of build dependencies by not pulling gcc.

Before:
```console
$ nix -Lv build . --dry-run
this derivation will be built:
  /nix/store/516w6ydn8v54bb5na9lcgwjn4dqpi7yn-xdg-ninja-0.1.0.drv
these 54 paths will be fetched (74.11 MiB download, 341.59 MiB unpacked):
...
```
After:
```console
$ nix -Lv build . --dry-run
this derivation will be built:
  /nix/store/11mifcs2x0ngca6l9gklwz8zwjp87k15-xdg-ninja-0.1.0.drv
these 41 paths will be fetched (18.35 MiB download, 87.14 MiB unpacked):
...
```