### PR TITLE
Add new-line character

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -66,7 +66,7 @@ help() {
     ${FX_ITALIC}--skip-unsupported${FX_RESET}  ${FX_BOLD}Don't display anything for files that do not have fixes available${FX_RESET}
 
     """
-    printf "%b" "$HELPSTRING"
+    printf "%b\n" "$HELPSTRING"
 }
 
 SKIP_OK=true


### PR DESCRIPTION
Thanks for xdg-ninja!

This PR adds a new-line character, so that `xdg-ninja -h` executes as I would expect.
Please take a look at the current output. I'm not sure how to describe what's going on.
Well, there's a character that's not supposed to be there..

See `printf "%d" 0x20` versus `printf "%d\n" 0x20`.

Perhaps I'm missing something though :)