### PR TITLE
Add crossnote.json (~/.mume)

### DIFF
--- a/programs/crossnote.json
+++ b/programs/crossnote.json
@@ -1,0 +1,10 @@
+{
+    "name": "crossnote",
+    "files": [
+        {
+            "path": "$HOME/.mume",
+            "movable": true,
+            "help": "Move the directory to $XDG_CONFIG_HOME/mume\n"
+        }
+    ]
+}


### PR DESCRIPTION
It's been supported since https://github.com/shd101wyy/crossnote/pull/234.