### PR TITLE
Add zsh_sessions entry to zsh

### DIFF
--- a/programs/zsh.json
+++ b/programs/zsh.json
@@ -1,6 +1,11 @@
 {
     "files": [
         {
+            "help": "Set this in your zshenv:\n\n```bash\nSHELL_SESSIONS_DISABLE=1\n```\n\nShould only exist on macOS when using the default terminal.\n",
+            "movable": true,
+            "path": "$HOME/.zsh_sessions"
+        },
+        {
             "help": "Set this in your zshrc:\n\n```bash\nzstyle ':completion:*' cache-path \"$XDG_CACHE_HOME\"/zsh/zcompcache\n```\n\nYou must manually create the _$XDG_CACHE_HOME/zsh_ directory if it doesn't exist yet.\n",
             "movable": true,
             "path": "$HOME/.zcompcache"


### PR DESCRIPTION
Thanks for centralizing all of this information into code, this tool is awesome!

## Details

Some info on the .zsh_sessions file can be found here: https://apple.stackexchange.com/questions/427561/macos-zsh-sessions-zsh-history-and-setopt-append-history

It only gets generated on MacOS when using the default terminal and can be disabled in the user zshenv file.