### PR TITLE
Add OrbStack

### DIFF
--- a/programs/orbstack.json
+++ b/programs/orbstack.json
@@ -1,0 +1,15 @@
+{
+    "name": "OrbStack",
+    "files": [
+        {
+            "path": "$HOME/.orbstack",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/orbstack/orbstack/issues/60\n"
+        },
+        {
+            "path": "$HOME/OrbStack",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/orbstack/orbstack/issues/239\n"
+        }
+    ]
+}


### PR DESCRIPTION
Add support for [OrbStack](https://orbstack.dev) ("*Fast, light, simple Docker & Linux on macOS*")

The tool creates `.orbstack` and `OrbStack` directories in `$HOME` ( 😿 )

Added links to discussions about XDG and directories: https://github.com/orbstack/orbstack/issues/60 & https://github.com/orbstack/orbstack/issues/239