### PR TITLE
Update and reformat `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,24 @@ Clone the repository somewhere, then run the _./xdg-ninja.sh_ script.
 
 This will run every test in the default configuration.
 
-### Installing with Homebrew
+### [Homebrew](https://brew.sh)
 
-To install xdg-ninja with [Homebrew](https://brew.sh), run `brew install xdg-ninja` to install the script and all of its dependencies, then run the `xdg-ninja` command.
+> [!NOTE]
+> Due to how `xdg-ninja` is developed, releases are not cut, so `brew` ships a stale version, therefore you have to install and upgrade `xdg-ninja` from the git HEAD. ref: [#204](https://github.com/b3nj5m1n/xdg-ninja/issues/204)
+>
+> Homebrew will not upgrade `xdg-ninja` when running a generic `brew upgrade`, you must specifically upgrade `xdg-ninja` from the git HEAD, _see below_
+
+Install:
+
+```sh
+brew install xdg-ninja --HEAD
+```
+
+Upgrade:
+
+```sh
+brew upgrade xdg-ninja --fetch-HEAD
+```
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ Upgrade:
 brew upgrade xdg-ninja --fetch-HEAD
 ```
 
-### Manual Installation
+### Other Package Managers
 
-Clone the repository, then run the [`./xdg-ninja.sh`](./xdg-ninja.sh) script.
+`xdg-ninja` is avaliable in many other package managers.
 
-This will run every test in the default configuration.
+The full list is available on the [repology page](https://repology.org/project/xdg-ninja/versions).
+
+Follow the instructions for your package manager to install `xdg-ninja`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,30 @@ Files in this directory can have any name, but using the name of the program is 
 
 ### Automatically Generating Configuration
 
-You can download the `xdgnj` executable from the releases page.
+For x86_64 Linux systems, you can download the `xdgnj` binary from the [releases page](https://github.com/b3nj5m1n/xdg-ninja/releases).
 
 Alternatively, you can build it from source using `cabal` or `stack`, use the nix flake or use the provided docker image.
 
 > To be clear, this is just a tool that will help you automatically generate the config files, you still only need your shell to run the tests
+
+#### Available commands
+
+```sh
+xdgnj add # Adds a new configuration
+xdgnj prev programs/FILE.json # Preview the configuration for a program
+xdgnj edit programs/FILE.json # Edit the configuration for a program
+xdgnj run # Mostly the same as running the shell script
+```
+
+#### Prebuilt Binaries
+
+> [!IMPORTANT]
+> The binaries only run on x86_64 Linux systems.
+
+```sh
+curl -fsSL -o xdgnj https://github.com/b3nj5m1n/xdg-ninja/releases/latest/download/xdgnj
+chmod +x xdgnj
+```
 
 #### Building from source
 
@@ -112,15 +131,6 @@ nix run github:b3nj5m1n/xdg-ninja#xdgnj-bin ...
 #### Docker
 
 Use the provided dockerfile in [`./haskell/build/`](./haskell/build/).
-
-Available commands:
-
-```sh
-xdgnj add # Adds a new configuration
-xdgnj prev programs/FILE.json # Preview the configuration for a program
-xdgnj edit programs/FILE.json # Edit the configuration for a program
-xdgnj run # Mostly the same as running the shell script
-```
 
 ### Manually Creating Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div>
   <h1 align="center">xdg-ninja</h1>
-  <h5 align="center">Because you wouldn't let just anyone into your <i>$HOME</i></h5>
+  <h5 align="center">
+    Because you wouldn't let just anyone into your <i>$HOME</i>
+  </h5>
 </div>
 
 A shell script which checks your _$HOME_ for unwanted files and directories.
@@ -18,6 +20,7 @@ The configurations are from the [arch wiki page on XDG_BASE_DIR](https://wiki.ar
 ### Using nix
 
 If you're using [nix](https://nixos.org) and have flakes turned on, you can just run the following command:
+
 ```sh
 nix run github:b3nj5m1n/xdg-ninja
 ```
@@ -59,7 +62,7 @@ brew upgrade xdg-ninja --fetch-HEAD
 
 ## Configuration
 
-The configuration is done in the _programs/_ directory, which should be located in the same working directory as the xdg-ninja.sh script. This can be overriden with the `XN_PROGRAMS_DIR` environment variable.
+The configuration is done in the _programs/_ directory, which should be located in the same working directory as the xdg-ninja.sh script. This can be overridden with the `XN_PROGRAMS_DIR` environment variable.
 
 You define a program, and then a list of files and directories which this program ruthlessly puts into your _$HOME_ directory.
 
@@ -74,6 +77,7 @@ Files in this directory can have any name, but using the name of the program is 
 You can download the _xdgnj_ executable from the releases page. Alternatively, you can use the nix flake or build it from scratch using _cabal_, _stack_, or the provided docker image in _build/_. (To be clear, this is just a tool that will help you automatically generate the config files, you still only need your shell to run the tests)
 
 Available commands:
+
 ```sh
 xdgnj add # Adds a new configuration
 xdgnj prev programs/FILE.json # Preview the configuration for a program
@@ -84,6 +88,7 @@ xdgnj run # Mostly the same as running the shell script
 #### Using nix
 
 If you're using [nix](https://nixos.org) and have flakes turned on, you can just run the following command:
+
 ```sh
 nix run github:b3nj5m1n/xdg-ninja#xdgnj-bin ...
 ```
@@ -101,29 +106,36 @@ It puts the file _.gitconfig_ into _$HOME_.
 Luckily, the XDG spec is supported by git, so we can simply move the file to _XDG_CONFIG_HOME/git/config_.
 
 We can use that last sentence as our instructions. In this case, there are no newlines, so escaping this string for use in json is trivial, however, this is how you should generally approach it:
+
 ```sh
 echo "Luckily, the XDG spec is supported by git, so we can simply move the file to _XDG_CONFIG_HOME/git/config_." | jq -aRs .
 ```
 
 Let's see what the output of this command looks like for something a little more sophisticated.
 Here's an example file:
+
 ```sh
 cat example.md
 ```
-```
+
+```sh
 Currently not fixable.
 
 _(But you can probably just delete the dir)_
 ```
+
 Here's what catting this file to the _jq_ command produces:
+
 ```sh
 cat example.md | jq -aRs .
 ```
-```
+
+```sh
 "Currently not fixable.\n\n_(But you can probably just delete the dir)_\n"
 ```
 
 Now, we can assemble our final json file:
+
 ```json
 {
     "name": "git",

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Luckily, the XDG spec is supported by git, so we can simply move the file to `$X
 We can use that last sentence as our instructions. In this case, there are no newlines, so escaping this string for use in json is trivial, however, this is how you should generally approach it:
 
 ```sh
-echo "Luckily, the XDG spec is supported by git, so we can simply move the file to `$XDG_CONFIG_HOME/git/config`." | jq -aRs .
+echo "Luckily, the XDG spec is supported by git, so we can simply move the file to _$XDG_CONFIG_HOME/git/config_." | jq -aRs .
 ```
 
 Let's see what the output of this command looks like for something a little more sophisticated.
@@ -169,7 +169,7 @@ Now, we can assemble our final json file:
         {
             "path": "$HOME/.gitconfig",
             "movable": true,
-            "help": "Luckily, the XDG spec is supported by git, so we can simply move the file to `$XDG_CONFIG_HOME/git/config`.\n"
+            "help": "Luckily, the XDG spec is supported by git, so we can simply move the file to _$XDG_CONFIG_HOME/git/config_.\n"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,40 +1,37 @@
-<div>
-  <h1 align="center">xdg-ninja</h1>
-  <h5 align="center">
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-configure-file { "no-inline-html": { "allowed_elements": [div, h1, h4, p, i, img] } } -->
+
+<div align="center">
+  <h1>xdg-ninja</h1>
+  <h4>
     Because you wouldn't let just anyone into your <i>$HOME</i>
-  </h5>
+  </h4>
 </div>
 
-A shell script which checks your _$HOME_ for unwanted files and directories.
+A shell script that checks your `$HOME` for unwanted files and directories.
 
 <p align="center">
-  <img src="https://s11.gifyu.com/images/68747470733a2f2f73382e67696679752e636f6d2f696d616765732f5065656b2d323032322d30352d31332d31362d30372e676966.gif" width="500"/>
+  <img src="https://s11.gifyu.com/images/68747470733a2f2f73382e67696679752e636f6d2f696d616765732f5065656b2d323032322d30352d31332d31362d30372e676966.gif" width="500" alt="xdg-ninja command output" />
 </p>
 
-When it encounters a file it knows about, it will tell you whether it's possible to move this file to an appropriate location, and how to do it.
+When `xdg-ninja` encounters a file or directory it knows about, it will tell you whether it's possible to move it to the appropriate location, and how to do it.
 
-The configurations are from the [arch wiki page on XDG_BASE_DIR](https://wiki.archlinux.org/title/XDG_Base_Directory), [antidot](https://github.com/doron-cohen/antidot) (thanks to Scr0nch for writing a conversion tool), and contributed by other users.
+The configurations are from the [arch wiki page on XDG_BASE_DIR](https://wiki.archlinux.org/title/XDG_Base_Directory), [antidot](https://github.com/doron-cohen/antidot) (thanks to Scr0nch for writing a conversion tool), and crowdsourced by other users.
 
-## Running
+## Installing
 
-### Using nix
+### [Nix](https://nixos.org)
 
-If you're using [nix](https://nixos.org) and have flakes turned on, you can just run the following command:
+Turn on [flakes](https://nixos.wiki/wiki/Flakes), then run the following command:
 
 ```sh
 nix run github:b3nj5m1n/xdg-ninja
 ```
 
-### Cloning Manually
-
-Clone the repository somewhere, then run the _./xdg-ninja.sh_ script.
-
-This will run every test in the default configuration.
-
 ### [Homebrew](https://brew.sh)
 
 > [!NOTE]
-> Due to how `xdg-ninja` is developed, releases are not cut, so `brew` ships a stale version, therefore you have to install and upgrade `xdg-ninja` from the git HEAD. ref: [#204](https://github.com/b3nj5m1n/xdg-ninja/issues/204)
+> Due to how `xdg-ninja` is developed, releases are not cut, so Homebrew ships a stale version, therefore you have to install and upgrade `xdg-ninja` from the git HEAD. ref: [#204](https://github.com/b3nj5m1n/xdg-ninja/issues/204)
 >
 > Homebrew will not upgrade `xdg-ninja` when running a generic `brew upgrade`, you must specifically upgrade `xdg-ninja` from the git HEAD, _see below_
 
@@ -50,31 +47,57 @@ Upgrade:
 brew upgrade xdg-ninja --fetch-HEAD
 ```
 
-## Dependencies
+### Manual Installation
 
-- your favorite POSIX-compliant shell ([bash](https://repology.org/project/bash/packages), [zsh](https://repology.org/project/zsh/packages), [dash](https://repology.org/project/dash-shell/packages), ...)
+Clone the repository, then run the [`./xdg-ninja.sh`](./xdg-ninja.sh) script.
+
+This will run every test in the default configuration.
+
+## Contributing
+
+### Dependencies
+
+- Your favorite POSIX-compliant shell ([bash](https://repology.org/project/bash/packages), [zsh](https://repology.org/project/zsh/packages), [dash](https://repology.org/project/dash-shell/packages), etc.)
 - [jq](https://repology.org/project/jq/packages) for parsing the json files
 - [find](https://repology.org/project/findutils/versions)
 
-### Optional
+#### Optional
 
-- [glow](https://repology.org/project/glow/packages) for rendering Markdown in the terminal ([bat](https://repology.org/project/bat-cat/packages), [pygmentize](https://repology.org/project/pygments/versions) or [highlight](https://repology.org/project/highlight/packages) can be used as fallback, but glow's output is clearer and therefore glow is recommended)
+- [glow](https://repology.org/project/glow/packages) for rendering Markdown in the terminal ([bat](https://repology.org/project/bat-cat/packages), [pygmentize](https://repology.org/project/pygments/versions) or [highlight](https://repology.org/project/highlight/packages) can be used as a fallback, but glow's output is clearer therefore glow is recommended)
 
-## Configuration
+### Configuration
 
-The configuration is done in the _programs/_ directory, which should be located in the same working directory as the xdg-ninja.sh script. This can be overridden with the `XN_PROGRAMS_DIR` environment variable.
+The configuration is done in the [`./programs/`](./programs/) directory, which should be located in the same working directory as the [`xdg-ninja.sh`](./xdg-ninja.sh) script. This can be overridden with the `XN_PROGRAMS_DIR` environment variable.
 
-You define a program, and then a list of files and directories which this program ruthlessly puts into your _$HOME_ directory.
+You define a program, and then a list of files and directories which that program ruthlessly puts into your `$HOME` directory.
 
 For each file/directory, you specify if it can be (re)moved.
 
 If this is the case, you also specify instructions on how to accomplish this in Markdown.
 
-Files in this directory can have any name, but using the name of the program is encouraged.
+Files in this directory can have any name, but using the name of the program is recommended.
 
 ### Automatically Generating Configuration
 
-You can download the _xdgnj_ executable from the releases page. Alternatively, you can use the nix flake or build it from scratch using _cabal_, _stack_, or the provided docker image in _build/_. (To be clear, this is just a tool that will help you automatically generate the config files, you still only need your shell to run the tests)
+You can download the `xdgnj` executable from the releases page.
+
+Alternatively, you can build it from source using `cabal` or `stack`, use the nix flake or use the provided docker image.
+
+> To be clear, this is just a tool that will help you automatically generate the config files, you still only need your shell to run the tests
+
+#### Building from source
+
+You can use `cabal build` or `stack build`
+
+#### Nix
+
+```sh
+nix run github:b3nj5m1n/xdg-ninja#xdgnj-bin ...
+```
+
+#### Docker
+
+Use the provided dockerfile in [`./haskell/build/`](./haskell/build/).
 
 Available commands:
 
@@ -85,52 +108,41 @@ xdgnj edit programs/FILE.json # Edit the configuration for a program
 xdgnj run # Mostly the same as running the shell script
 ```
 
-#### Using nix
+### Manually Creating Configuration
 
-If you're using [nix](https://nixos.org) and have flakes turned on, you can just run the following command:
+We're going to use `git` as an example.
 
-```sh
-nix run github:b3nj5m1n/xdg-ninja#xdgnj-bin ...
-```
+By default, it puts the file `.gitconfig` into `$HOME`.
 
-#### Building from scratch
-
-You can use `cabal build`, `stack build`, or the provided dockerfile in _build/_.
-
-### Manually
-
-We're going to use _git_ as an example.
-
-It puts the file _.gitconfig_ into _$HOME_.
-
-Luckily, the XDG spec is supported by git, so we can simply move the file to _XDG_CONFIG_HOME/git/config_.
+Luckily, the XDG spec is supported by git, so we can simply move the file to `$XDG_CONFIG_HOME/git/config`.
 
 We can use that last sentence as our instructions. In this case, there are no newlines, so escaping this string for use in json is trivial, however, this is how you should generally approach it:
 
 ```sh
-echo "Luckily, the XDG spec is supported by git, so we can simply move the file to _XDG_CONFIG_HOME/git/config_." | jq -aRs .
+echo "Luckily, the XDG spec is supported by git, so we can simply move the file to `$XDG_CONFIG_HOME/git/config`." | jq -aRs .
 ```
 
 Let's see what the output of this command looks like for something a little more sophisticated.
+
 Here's an example file:
 
 ```sh
 cat example.md
 ```
 
-```sh
+```text
 Currently not fixable.
 
 _(But you can probably just delete the dir)_
 ```
 
-Here's what catting this file to the _jq_ command produces:
+Here's what catting this file into `jq` produces:
 
 ```sh
 cat example.md | jq -aRs .
 ```
 
-```sh
+```text
 "Currently not fixable.\n\n_(But you can probably just delete the dir)_\n"
 ```
 
@@ -143,12 +155,12 @@ Now, we can assemble our final json file:
         {
             "path": "$HOME/.gitconfig",
             "movable": true,
-            "help": "Luckily, the XDG spec is supported by git, so we can simply move the file to _XDG_CONFIG_HOME/git/config_.\n"
+            "help": "Luckily, the XDG spec is supported by git, so we can simply move the file to `$XDG_CONFIG_HOME/git/config`.\n"
         }
     ]
 }
 ```
 
-Saving this as _git.json_ in the _programs/_ directory will result in the script picking it up and checking the file.
+Saving this as `git.json` in the [`./programs/`](./programs/) directory will result in the script picking it up and checking the file.
 
 If you've created a configuration for a file that isn't in the official repository yet, make sure to create a pull request so that other people can benefit from it as well.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ The configurations are from the [arch wiki page on XDG_BASE_DIR](https://wiki.ar
 
 ## Installing
 
+### Manual Installation
+
+Clone the repository, then run the [`./xdg-ninja.sh`](./xdg-ninja.sh) script.
+
+```sh
+git clone https://github.com/b3nj5m1n/xdg-ninja
+cd xdg-ninja
+./xdg-ninja.sh
+```
+
+This will run every test in the default configuration.
+
 ### [Nix](https://nixos.org)
 
 Turn on [flakes](https://nixos.wiki/wiki/Flakes), then run the following command:


### PR DESCRIPTION
I've updated the install section for Homebrew to install from the git HEAD, instead of the latest release tag. ref: #204

I've also reformatted and changed the verbage of the README to be more consice and clear.
The README now follows `markdownlint` rules, and best practices for markdown.

I made sure to not change the actual meaning of the README's contents, just the way it was presented.

If you feel like the changes are not appropriate, please let me know and I'll revert them, keeping only the updated Homebrew install instructions.

If you have any questions or suggestions, please let me know.
