### PR TITLE
Add PokeMMO

### DIFF
--- a/programs/pokemmo.json
+++ b/programs/pokemmo.json
@@ -1,0 +1,11 @@
+{
+	"name": "pokemmo",
+	"files": [
+		{
+			"path": "$HOME/.pokemmo",
+			"movable": true,
+			"help": "Supported by default, you can move this directory to _$XDG_DATA_HOME/pokemmo_.\n"
+		}
+	]
+}
+


### PR DESCRIPTION
Thanks for this tool, very useful!

## Details
PokeMMO seems to have implemented XDG since some time between August 2022 and April 2023, and uses `$HOME/.local/share` by default now – unfortunately I couldn't find any docs about it, and PokeMMO is closed source, so am just basing off write times in my filesystem.
```
$ ls -la ~/.pokemmo
total 23M
drwxr-xr-x  8 cotton cotton 4.0K Aug 12  2022 .
...
```
```
$ ls -la $XDG_DATA_HOME/pokemmo 
total 28M
drwxr-xr-x   8 cotton cotton 4.0K May  6 20:50 .
...
```
