### PR TITLE
Add lyrics entry to ncmpcpp

### DIFF
--- a/programs/ncmpcpp.json
+++ b/programs/ncmpcpp.json
@@ -5,6 +5,11 @@
             "path": "$HOME/.ncmpcpp",
             "movable": true,
             "help": "Supported by default.\n\nYou can move the directory to _$XDG_CONFIG_HOME/ncmpcpp_.\n\nNote that the _error.log_ file will still be created at the old location. To avoid that, set `ncmcpp_directory` in your config file.\n"
+        },
+        {
+            "path": "$HOME/.lyrics",
+            "movable": true,
+            "help": "This directory is where _ncmpcpp_ stores lyrics by default, for other _mpd_ clients also use this default path. You can move it to elsewhere, say `$XDG_CONFIG_HOME/lyrics`, but it works __only if you only use _ncmpcpp___.\n\nSupposed your `$XDG_CONFIG_HOME` is set to `~/.local/share`.\nPut the following to your _ncmpcpp_ configuration, usually `$XDG_CONFIG_HOME/ncmpcpp/config`\n\n```\nlyrics_directory = ~/.local/share/lyrics\n```\n\n"
         }
     ]
 }


### PR DESCRIPTION
# Commit detail
By default, ncmpcpp creates `~/.lyrics` to store lyrics, other mpd clients use this directory too. For ncmpcpp users, this behavior can be changed by modifying ncmpcpp config file. But it may not work if other mpd clients exists.
see `man ncmpcpp`, search `lyrics` to get more information.

# Conflicts
However, this directory seems used by an existing program named `lyrics` in xdg-ninja. So currently, when user run xdg-ninja, both entries appear, which may cause some confusion.

![lyrics](https://github.com/b3nj5m1n/xdg-ninja/assets/133017480/c5b7af5e-5f5d-4dd2-8c6d-aaf2022659e1)

