### PR TITLE
Add EmulationStation DE

### DIFF
--- a/programs/es-de.json
+++ b/programs/es-de.json
@@ -4,12 +4,12 @@
 		{
 			"path": "$HOME/.emulationstation",
 			"movable": true,
-			"help": "Export the following environment variable:\n\n```bash\nexport ESDE_APPDATA_DIR=\"$XDG_DATA_HOME\"/ES-DE\n```\n"
+			"help": "Export the following environment variable:\n\n```bash\nexport ESDE_APPDATA_DIR=\"$XDG_CONFIG_HOME\"/ES-DE\n```\n"
 		},
 		{
 			"path": "$HOME/ES-DE",
 			"movable": true,
-			"help": "Export the following environment variable:\n\n```bash\nexport ESDE_APPDATA_DIR=\"$XDG_DATA_HOME\"/ES-DE\n```\n"
+			"help": "Export the following environment variable:\n\n```bash\nexport ESDE_APPDATA_DIR=\"$XDG_CONFIG_HOME\"/ES-DE\n```\n"
 		}
 	]
 }

--- a/programs/es-de.json
+++ b/programs/es-de.json
@@ -1,0 +1,15 @@
+{
+	"name": "emulationstation-de",
+	"files": [
+		{
+			"path": "$HOME/.emulationstation",
+			"movable": true,
+			"help": "Export the following environment variable:\n\n```bash\nexport ESDE_APPDATA_DIR=\"$XDG_DATA_HOME\"/ES-DE\n```\n"
+		},
+		{
+			"path": "$HOME/ES-DE",
+			"movable": true,
+			"help": "Export the following environment variable:\n\n```bash\nexport ESDE_APPDATA_DIR=\"$XDG_DATA_HOME\"/ES-DE\n```\n"
+		}
+	]
+}


### PR DESCRIPTION
## Details
ES-DE accepts the environment variable `ESDE_APPDATA_DIR` since [v3.0.1](https://gitlab.com/es-de/emulationstation-de/-/releases/v3.0.1).

The `.emulationstation` folder was deprecated in [v3.0.0](https://gitlab.com/es-de/emulationstation-de/-/releases/v3.0.0), and if no `ESDE_APPDATA_DIR` value is set then ES will prompt to rename it to `ES-DE`, which is the new default folder.

[ES-DE XDG GitLab issue](https://gitlab.com/es-de/emulationstation-de/-/issues/1622).