### PR TITLE
Fix `.tmux` output suggesting incorrect target path.

### DIFF
--- a/programs/tmux.json
+++ b/programs/tmux.json
@@ -9,7 +9,7 @@
         {
             "path": "$HOME/.tmux",
             "movable": true,
-            "help": "Set this in your tmux.conf:\n\n```set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.local/share/tmux/plugins'```\n\nThen update the path to tpm to:\n\n```run '~/.local/share/tmux/plugins/tpm/tpm'```\n\nNow move .tmux to _XDG_CONFIG_HOME_/tmux.\n"
+            "help": "Set this in your tmux.conf:\n\n```set-environment -g TMUX_PLUGIN_MANAGER_PATH '~/.local/share/tmux/plugins'```\n\nThen update the path to tpm to:\n\n```run '~/.local/share/tmux/plugins/tpm/tpm'```\n\nNow move .tmux to _XDG_DATA_HOME_/tmux.\n"
         }
     ]
 }


### PR DESCRIPTION
The previous `.tmux` output instructed users to update their TPM run command to `run ~/.local/share/...`, which is typically represented by `XDG_DATA_HOME`. However, the directions also told users to then move the corresponding `.tmux` directory to `XDG_CONFIG_HOME/tmux`.

The two halves of the instructions were conflicting.

To resolve this, this commit fixes the second half of the instructions with the correct target path (i.e., `XDG_DATA_HOME`).