### PR TITLE
Fix fontconfig base dirs

### DIFF
--- a/programs/fontconfig.json
+++ b/programs/fontconfig.json
@@ -4,12 +4,12 @@
         {
             "path": "$HOME/.fontconfig",
             "movable": true,
-            "help": "Supported\n\nThe file $HOME/.fontconfig can be moved to $XDG_DATA_HOME/fontconfig.\n"
+            "help": "Supported\n\nThe file $HOME/.fontconfig can be moved to $XDG_CACHE_HOME/fontconfig.\n"
         },
         {
             "path": "$HOME/.fonts.conf",
             "movable": true,
-            "help": "Supported\n\nThe file $HOME/.fonts.conf can be moved to $XDG_DATA_HOME/fontconfig/fonts.conf.\n"
+            "help": "Supported\n\nThe file $HOME/.fonts.conf can be moved to $XDG_CONFIG_HOME/fontconfig/fonts.conf.\nThe <dir> element may be changed to <dir prefix=\"xdg\">fonts</dir>\n"
         }
     ]
 }


### PR DESCRIPTION
According to https://www.freedesktop.org/software/fontconfig/fontconfig-user.html :

1) Fixes an typo in #218: It did not add `$XDG_CONFIG_HOME` but `$XDG_DATA_HOME` as the destination for `${HOME}/.fonts.conf`.
Also the possibility of one needing to change the `<dir>` element in the config is now mentioned.

2) While investigating I also noticed that `${HOME}/.fontconfig` should be moved to `$XDG_CACHE_HOME/fontconfig` instead of `${XDG_DATA_HOME}/fontconfig`

This PR closes #388