### PR TITLE
Update swift package manager

### DIFF
--- a/programs/swift-package-manager.json
+++ b/programs/swift-package-manager.json
@@ -3,8 +3,8 @@
     "files": [
         {
             "path": "$HOME/.swiftpm",
-            "movable": false,
-            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/apple/swift-package-manager/issues/6204\n"
+            "movable": true,
+            "help": "Set the _$XDG_CONFIG_HOME_ environment variable\n\nOnce set, Swift Package Manager will store its configuration files in _$XDG_CONFIG_HOME/swiftpm_."
         }
     ]
 }


### PR DESCRIPTION
Swift 6 and Swift Package Manger 6 was released today with macOS Sequoia.

Swift Package Manager now supports `$XDG_CONFIG_HOME` if set.

ref: https://github.com/swiftlang/swift-package-manager/pull/7386

Closes #399 