### PR TITLE
Fix wrong suggested variable quotation in help text for `wakatime`

### DIFF
--- a/programs/wakatime.json
+++ b/programs/wakatime.json
@@ -4,22 +4,22 @@
         {
             "path": "$HOME/.wakatime.cfg",
             "movable": true,
-            "help": "export WAKATIME_HOME='$XDG_CONFIG_HOME/wakatime'\n\nThe directory needs to be created manually\n\nmkdir '$XDG_CONFIG_HOME/wakatime'" 
+            "help": "export WAKATIME_HOME=\"$XDG_CONFIG_HOME\"/wakatime\n\nThe directory needs to be created manually\n\nmkdir \"$XDG_CONFIG_HOME\"/wakatime"
         },
         {
             "path": "$HOME/.wakatime.data",
             "movable": true,
-            "help": "export WAKATIME_HOME='$XDG_CONFIG_HOME/wakatime'\n\nThe directory needs to be created manually\n\nmkdir '$XDG_CONFIG_HOME/wakatime'" 
+            "help": "export WAKATIME_HOME=\"$XDG_CONFIG_HOME\"/wakatime\n\nThe directory needs to be created manually\n\nmkdir \"$XDG_CONFIG_HOME\"/wakatime"
         },
         {
             "path": "$HOME/.wakatime.db",
             "movable": true,
-            "help": "export WAKATIME_HOME='$XDG_CONFIG_HOME/wakatime'\n\nThe directory needs to be created manually\n\nmkdir '$XDG_CONFIG_HOME/wakatime'" 
+            "help": "export WAKATIME_HOME=\"$XDG_CONFIG_HOME\"/wakatime\n\nThe directory needs to be created manually\n\nmkdir \"$XDG_CONFIG_HOME\"/wakatime"
         },
         {
             "path": "$HOME/.wakatime.log",
             "movable": true,
-            "help": "export WAKATIME_HOME='$XDG_CONFIG_HOME/wakatime'\n\nThe directory needs to be created manually\n\nmkdir '$XDG_CONFIG_HOME/wakatime'" 
+            "help": "export WAKATIME_HOME=\"$XDG_CONFIG_HOME\"/wakatime\n\nThe directory needs to be created manually\n\nmkdir \"$XDG_CONFIG_HOME\"/wakatime"
         }
     ]
 }


### PR DESCRIPTION
At least when using Bash, putting `$var` in single quotes, prints the text inside as-is instead of replacing the variable with its value.