### PR TITLE
Add program JSON for install4j

### DIFF
--- a/programs/install4j.json
+++ b/programs/install4j.json
@@ -1,0 +1,10 @@
+{
+    "name": "install4j",
+    "files": [
+        {
+            "path": "$HOME/.install4j",
+            "movable": false,
+            "help": "XDG is supported out-of-the-box for newer versions of *install4j*,\nbut apps using old versions of it will continue to use the old location.\n\nYou can delete the file without harm, but it might be regenerated.\n"
+        }
+    ]
+}


### PR DESCRIPTION
I've contact the install4j support about the file and it looks like one of my installed apps uses an old version of install4j:

> Thanks for your email.
> Older versions of install4j used the `.install4j` file in the home directory to cache JRE version information.
> Recent versions write that information to `$XDG_CACHE_HOME`.
> Unfortunately, there is no way to move this file somewhere else.
> You can delete the file, it will be recreated if necessary.


I hope the JSON looks how it is supposed to look