### PR TITLE
Add program JSON for MakeMKV

### DIFF
--- a/programs/makemkv.json
+++ b/programs/makemkv.json
@@ -1,0 +1,15 @@
+{
+    "name": "MakeMKV",
+    "files": [
+        {
+            "path": "$HOME/.MakeMKV",
+            "movable": false,
+            "help": "Currently unsupported.\n\nIf you really want to get rid of it, you can try overwriting `$HOME` for MakeMKV\ne.g. by creating a wrapper script `~/.local/bin/makemkv`:\n```sh\n#!/bin/sh\nexport HOME=\"${XDG_STATE_HOME:-$HOME/.local/state}\"/makemkv\nmkdir --parent \"$HOME\"\n/usr/bin/makemkv\n```\n"
+        },
+        {
+            "path": "$HOME/MakeMKV_log.txt",
+            "movable": false,
+            "help": "Currently unsupported.\n\nIf you really want to get rid of it, you can try overwriting `$HOME` for MakeMKV\ne.g. by creating a wrapper script `~/.local/bin/makemkv`:\n```sh\n#!/bin/sh\nexport HOME=\"${XDG_STATE_HOME:-$HOME/.local/state}\"/makemkv\nmkdir --parent \"$HOME\"\n/usr/bin/makemkv\n```\n"
+        }
+    ]
+}


### PR DESCRIPTION
MakeMKV is closed source and it looks like it does not support configuring the relevant directory: https://forum.makemkv.com/forum/viewtopic.php?p=160140

The help text provides an example wrapper script which overrides `$HOME` for MakeMKV (a workaround).
I haven't had any issues with that yet and `$HOME` being overridden only for MakeMKV *should* probably be fine?

Let me know, if mentioning the wrapper script is out-of-scope for xdg-ninja or should be done differently.