### PR TITLE
Add Jameica and J-Pilot, fix typo for Docker

### DIFF
--- a/programs/docker.json
+++ b/programs/docker.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.docker",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport DOCKER_CONFIG=\"$XDG_CONFIG_HOME\"/docker\n```\n\n_Note: docker-desktop won't follow this rulling, see:_ [https://github.com/docker/roadmap/issues/408](https://github.com/docker/roadmap/issues/408)\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport DOCKER_CONFIG=\"$XDG_CONFIG_HOME\"/docker\n```\n\n_Note: docker-desktop won't follow this ruling, see:_ [https://github.com/docker/roadmap/issues/408](https://github.com/docker/roadmap/issues/408)\n"
         }
     ],
     "name": "docker"

--- a/programs/jameica.json
+++ b/programs/jameica.json
@@ -1,0 +1,15 @@
+{
+    "name": "jameica",
+    "files": [
+        {
+            "path": "$HOME/.jameica",
+            "movable": true,
+            "help": "The path to this directory can be adjusted freely inside _.jameica.properties_.\n"
+        },
+        {
+            "path": "$HOME/.jameica.properties",
+            "movable": false,
+            "help": "Currently unsupported.\n"
+        }
+    ]
+}

--- a/programs/jpilot.json
+++ b/programs/jpilot.json
@@ -1,0 +1,10 @@
+{
+    "name": "jpilot",
+    "files": [
+        {
+            "path": "$HOME/.jpilot",
+            "movable": true,
+            "help": "Export the following environment variables:\n\n```bash\nexport JPILOT_HOME=\"$XDG_DATA_HOME\"\n```\n"
+        }
+    ]
+}


### PR DESCRIPTION
- Added a manifest for [Jameica](https://www.willuhn.de/products/jameica/). The program first looks for `$HOME/.jameica.properties` (this path is [hardcoded](https://github.com/willuhn/jameica/blob/82d5d345fec35f02b881495e64cb56f1e09eb778/src/de/willuhn/jameica/system/BootstrapSettings.java#L192)), in which the path to the actual program directory can be set freely (though it [defaults](https://github.com/willuhn/jameica/blob/82d5d345fec35f02b881495e64cb56f1e09eb778/src/de/willuhn/jameica/system/Platform.java#L174) to `$HOME/.jameica`).
- Added a manifest for [J-Pilot](https://github.com/juddmon/jpilot). The program [supports](https://github.com/juddmon/jpilot/?tab=readme-ov-file#environment-variables) setting `JPILOT_HOME`, however, this refers to the parent directory (a `.jpilot` folder is always created), which is why the manifest sets it to `$XDG_DATA_HOME` (instead of something like `$XDG_DATA_HOME/jpilot`).
- Fixed a typo in the Docker manifest.