### PR TITLE
Missing three $ in conda help

### DIFF
--- a/programs/conda.json
+++ b/programs/conda.json
@@ -1,17 +1,17 @@
 {
     "files": [
         {
-            "help": "Move the file to _\"XDG_CONFIG_HOME\"/conda/.condarc_.\n\n_See conda documentation for details:_ https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc\n",
+            "help": "Move the file to _\"$XDG_CONFIG_HOME\"/conda/.condarc_.\n\n_See conda documentation for details:_ https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc\n",
             "movable": true,
             "path": "$HOME/.condarc"
         },
         {
-            "help": "Move the file to _\"XDG_CONFIG_HOME\"/conda/.condarc_.\n\n_See conda documentation for details:_ https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc\n",
+            "help": "Move the file to _\"$XDG_CONFIG_HOME\"/conda/.condarc_.\n\n_See conda documentation for details:_ https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc\n",
             "movable": true,
             "path": "$HOME/.conda/.condarc"
         },
         {
-            "help": "Move the file to _\"XDG_CONFIG_HOME\"/conda/condarc_.\n\n_See conda documentation for details:_ https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc\n",
+            "help": "Move the file to _\"$XDG_CONFIG_HOME\"/conda/condarc_.\n\n_See conda documentation for details:_ https://conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#searching-for-condarc\n",
             "movable": true,
             "path": "$HOME/.conda/condarc"
         },


### PR DESCRIPTION
Hi, this is a minor PR to fix a small issue in the conda help text. I noticed that there were three missing dollar signs ($).