### PR TITLE
Update .Renviron to use curly brackets for Environment Variables

### DIFF
--- a/programs/R.json
+++ b/programs/R.json
@@ -4,7 +4,7 @@
         {
             "path": "$HOME/R",
             "movable": true,
-            "help": "Set R_LIBS_USER in `$HOME/.Renviron:\n\n```\nR_LIBS_USER=\"$XDG_DATA_HOME\"/R/x86_64-pc-linux-gnu-library\n```\n\nYou may find it necessary to append this line to the end of `/usr/lib/R/library/base/R/Rprofile`:\n\n```R.libPaths( c( \"$XDG_DATA_HOME/R/x86_64-pc-linux-gnu-library/\" , .libPaths() ) )```\n\n**Disclaimer: You may need to re-install your libraries**"
+            "help": "Set R_LIBS_USER in `$HOME/.Renviron:\n\n```\nR_LIBS_USER=\"${XDG_DATA_HOME}\"/R/x86_64-pc-linux-gnu-library\n```\n\nYou may find it necessary to append this line to the end of `/usr/lib/R/library/base/R/Rprofile`:\n\n```R.libPaths( c( \"$XDG_DATA_HOME/R/x86_64-pc-linux-gnu-library/\" , .libPaths() ) )```\n\n**Disclaimer: You may need to re-install your libraries**"
         },
         {
             "path": "$HOME/.Rprofile",


### PR DESCRIPTION
I utilized this tool to clean my home environment, and everything worked perfectly, with one exception: upon starting RStudio, a `$XDG_DATA_HOME` folder was created. Yes, the full name not the value of the variable.

Upon investigation, I discovered that the `.Renviron` file requires environment variables to be encapsulated in curly brackets.

This pull request addresses this issue by updating the `.Renviron` file accordingly.
