### PR TITLE
docs: update the link of demo gif for xdg-ninja command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 A shell script that checks your `$HOME` for unwanted files and directories.
 
 <p align="center">
-  <img src="https://s11.gifyu.com/images/68747470733a2f2f73382e67696679752e636f6d2f696d616765732f5065656b2d323032322d30352d31332d31362d30372e676966.gif" width="500" alt="xdg-ninja command output" />
+  <img src="https://github.com/user-attachments/assets/4b406636-8a00-41da-9ed2-46f02c5789ab" width="500" alt="xdg-ninja command output" />
 </p>
 
 When `xdg-ninja` encounters a file or directory it knows about, it will tell you whether it's possible to move it to the appropriate location, and how to do it.


### PR DESCRIPTION
The link of demo gif in README.md is broken.

So I tried to find the [original picture on WebArchive](https://web.archive.org/web/20220711083017im_/https://camo.githubusercontent.com/fbbe18b7940bc6630872db5b8d4b6e5f955533f0c32d6f2f9944e6a5ed211148/68747470733a2f2f73382e67696679752e636f6d2f696d616765732f5065656b2d323032322d30352d31332d31362d30372e676966), reuploaded it to GitHub, and use the new link to update README.md.