### PR TITLE
feat: add tip for bash history

### DIFF
--- a/programs/bash.json
+++ b/programs/bash.json
@@ -33,7 +33,7 @@
         {
             "path": "$HOME/.bash_history",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport HISTFILE=\"${XDG_STATE_HOME}\"/bash/history\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport HISTFILE=\"${XDG_STATE_HOME}\"/bash/history\n```\n and create the exported file (it is not created automatically)\n"
         }
     ],
     "name": "bash"


### PR DESCRIPTION
I was wondering why my history file was not being used when using reverse search, because I added `export HISTFILE="${XDG_STATE_HOME}"/bash/history` as was instructed. Turns out the file needs to exist and is not created automatically. 

I added a simple helper message that points this out:
<img width="533" height="152" alt="image" src="https://github.com/user-attachments/assets/36e7fa4c-45be-4da1-94e1-7beec9d87678" />


