### PR TITLE
Add support for 1Password CLI.

### DIFF
--- a/programs/op.json
+++ b/programs/op.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.op",
+            "movable": true,
+            "help": "Move to `$XDG_CONFIG_HOME/op` and alias op to use a custom configuration location:\n\n```bash\nalias op=\"op --config=${XDG_CONFIG_HOME}/op\"\n```\n"
+        }
+    ],
+    "name": "1Password CLI"
+}


### PR DESCRIPTION
While not XDG compliant, the `.op` directory it creates by default can be relocated and its location specified at runtime.