### PR TITLE
Update aspell/hunspell entries; add other new programs

### DIFF
--- a/programs/abcde.json
+++ b/programs/abcde.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.abcde.conf",
+            "movable": false,
+            "help": "Currently unsupported.\n"
+        }
+    ],
+    "name": "abcde"
+}

--- a/programs/aspell.json
+++ b/programs/aspell.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "path": "$HOME/.aspell.conf",
+            "path": "$HOME/.aspell.*",
             "movable": true,
             "help": "Export the following environment variables:\n\n```bash\nexport ASPELL_CONF=\"per-conf $XDG_CONFIG_HOME/aspell/aspell.conf; personal $XDG_CONFIG_HOME/aspell/en.pws; repl $XDG_CONFIG_HOME/aspell/en.prepl\"\n```\n"
         }

--- a/programs/hunspell.json
+++ b/programs/hunspell.json
@@ -2,7 +2,7 @@
     "name": "hunspell",
     "files": [
         {
-            "path": "$HOME/.hunspell_default",
+            "path": "$HOME/.hunspell_*",
             "movable": false,
             "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/hunspell/hunspell/pull/637\n"
         }

--- a/programs/reportbug.json
+++ b/programs/reportbug.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.reportbugrc",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=787911\n"
+        }
+    ],
+    "name": "reportbug"
+}

--- a/programs/runelite.json
+++ b/programs/runelite.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.runelite",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant issue:_ https://github.com/runelite/runelite/issues/7940\n"
+        }
+    ],
+    "name": "runelite"
+}

--- a/programs/shellcheck.json
+++ b/programs/shellcheck.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.shellcheckrc",
+            "movable": true,
+            "help": "Supported by default.\n\nYou can move the file to _$XDG_CONFIG_HOME/.shellcheckrc_.\n"
+        }
+    ],
+    "name": "shellcheck"
+}

--- a/programs/xmodmap.json
+++ b/programs/xmodmap.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.Xmodmap",
+            "movable": false,
+            "help": "Currently unsupported.\n"
+        }
+    ],
+    "name": "xmodmap"
+}


### PR DESCRIPTION
The first commit helps match dictionary/repl files created by aspell and hunspell. The commits following that provide matchers for the following programs:
* [abcde](https://abcde.einval.com/wiki/)
* [reportbug](https://wiki.debian.org/reportbug)
* [RuneLite](https://runelite.net)
* [shellcheck](https://www.shellcheck.net/)
* [xmodmap](https://gitlab.freedesktop.org/xorg/app/xmodmap)