### PR TITLE
Add xargs to pass the list of programs to jq

### DIFF
--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -230,7 +230,7 @@ do_check_programs() {
 " read -r name; read -r filename; read -r movable; read -r help; do
         check_file "$name" "$filename" "$movable" "$help"
     done <<EOF
-$(jq '.files[] as $file | .name, $file.path, $file.movable, $file.help' "$XN_PROGRAMS_DIR"/* | sed -e 's/^"//' -e 's/"$//')
+$(find "$XN_PROGRAMS_DIR" -type f -print0 | xargs -0 jq '.files[] as $file | .name, $file.path, $file.movable, $file.help' | sed -e 's/^"//' -e 's/"$//')
 EOF
 # sed is to trim quotes
 }


### PR DESCRIPTION
Depending on the operating system the argument list has a limit. On Windows this is 8191 characters:

https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation

The current list of programs in xdg-ninja already passes this limit, so the script throws the following error:

> ./xdg-ninja.sh: line 228: /c/Users/USERNAME/.local/bin/jq:
> Argument list too long

This commit will use `find` and `xargs` to pass the list of programs to `jq` to solve this issue. The list of program files needs to be terminated by a null character (zero byte) so that `xargs` ignores the whitespace in the "zen browser.json" filename. Both `find` and `xargs` are used elsewhere in xdg-ninja already, so using them should not be a problem.