### PR TITLE
Add support for fjira

### DIFF
--- a/programs/fjira.json
+++ b/programs/fjira.json
@@ -1,0 +1,10 @@
+{
+    "name": "fjira",
+    "files": [
+        {
+            "path": "$HOME/.fjira",
+            "movable": true,
+            "help": "Luckily, the XDG spec is supported by fjira, so we can simply move the file to _$XDG_CONFIG_HOME/fjira_.\n"
+        }
+    ]
+}


### PR DESCRIPTION
Added support for [fjira](https://github.com/mk-5/fjira), which natively supports configuration within the `XDG_CONFIG_HOME` directory