### PR TITLE
add enigma

### DIFF
--- a/programs/enigma.json
+++ b/programs/enigma.json
@@ -1,0 +1,15 @@
+{
+    "files": [
+        {
+            "help": "Alias enigma to use a custom configuration location:\n\n```bash\nalias enigma=enigma --pref \"$XDG_DATA_HOME\"/enigma\n```\n",
+            "movable": true,
+            "path": "$HOME/.enigma/"
+        },
+        {
+            "help": "Alias enigma to use a custom configuration location:\n\n```bash\nalias enigma=enigma --pref \"$XDG_DATA_HOME\"/enigma\n```\n",
+            "movable": true,
+            "path": "$HOME/.enigmarc.xml"
+        }
+    ],
+    "name": "enigma"
+}


### PR DESCRIPTION
https://www.nongnu.org/enigma/
https://github.com/Enigma-Game/Enigma

by default enigma creates `$HOME/.enigmarc.xml` as a config file and `$HOME/.enigma` for data - ideally we'd put `$HOME/.enigmarc.xml` into `$XDG_CONFIG_HOME/enigma/enigmarc.xml` and `$HOME/.enigma` into `$XDG_DATA_HOME/enigma` but unfortunately enigma only gives us the `--pref` flag, so I decided it's better to put everything into `$XDG_DATA_HOME` - let me know if that should be changed