### PR TITLE
feat(programs/codex): init

### DIFF
--- a/programs/codex.json
+++ b/programs/codex.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.codex",
+            "movable": true,
+            "help": "Export the following environment variables:\n\n```bash\nexport CODEX_HOME=\"$XDG_CONFIG_HOME\"/codex\n```\n"
+        }
+    ],
+    "name": "codex"
+}

--- a/programs/codex.json
+++ b/programs/codex.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.codex",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport CODEX_HOME=\"$XDG_CONFIG_HOME\"/codex\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport CODEX_HOME=\"$XDG_CONFIG_HOME\"/codex\n```\nWarning: also contains data that isn't configuration.\n"
         }
     ],
     "name": "codex"


### PR DESCRIPTION
The [official configuration documentation](https://github.com/openai/codex/blob/main/docs/config.md) states that the `CODEX_HOME` environment value where it defaults to `~/.codex` will be where the configuration file `$CODEX_HOME/config.toml`, logs and other Codex-related information are stored.