### PR TITLE
Add support for ly log file

### DIFF
--- a/programs/ly.json
+++ b/programs/ly.json
@@ -1,0 +1,10 @@
+{
+    "name": "ly",
+    "files": [
+        {
+            "path": "$HOME/ly-session.log",
+            "movable": true,
+            "help": "By default `ly` saves its log file in the user's home directory.\n\nYou can move `ly-session.log` by changing the value of `session_log`\nfield in _/etc/ly/config.ini_ file using your favourite editor.\n\n```bash\n$ sudo nano /etc/ly/config.ini      # using nano\n$ sudo vim /etc/ly/config.ini       # using vim\n```\n\n(_/etc/ly/config.ini_)\n```config\nsession_log = .local/state/ly-session.log\n```\n"
+        }
+    ]
+}


### PR DESCRIPTION
ly is a Display manager (login manager) that stores its log file in the _home_ directory. the ly log file can be easily moved by editing its config file in the `/etc/ly/config.ini` file.

Since the ly config file is located in `/etc` directory, it doesn't support shell variables like `$HOME` or `$XDG_STATE_HOME`, but it can support it natively by hard coding `.local/state/` in its config instead of `$XDG_STATE_HOME`.

This PR adds a `programs/ly.json` file, which contains instructions on how to move it.