### PR TITLE
Fix .gitignore rule description

### DIFF
--- a/programs/git.json
+++ b/programs/git.json
@@ -18,8 +18,8 @@
         },
         {
             "path": "$HOME/.gitignore",
-            "movable": true,
-            "help": "XDG is supported out-of-the-box, so we can simply move the file to _$XDG_CONFIG_HOME/git/ignore_.\n"
+            "movable": false,
+            "help": "If your _$HOME_ directory is a git repository - this file is the correct way to ignore files in it. For global gitignore, use _$XDG_CONFIG_HOME/git/ignore_.\n"
         }
     ]
 }


### PR DESCRIPTION
`.gitignore` rule initially was not there, then it was added in #215 with incorrect description, removed in #416 with a good reasoning, and then added again in #479 with the same text as in #215.

To avoid third reintroduction of this rule I suggest marking it as not movable instead and adding more descriptive description to explain what's the difference between `~/.gitignore` and `~/.config/git/ignore`.