### PR TITLE
Add rule for Clojure ~/.gitlibs directory

### DIFF
--- a/programs/clojure.json
+++ b/programs/clojure.json
@@ -5,6 +5,11 @@
             "path": "$HOME/.clojure",
             "movable": true,
             "help": "XDG is supported out-of-the-box, so we can simply move the directory to _$XDG_CONFIG_HOME/clojure_.\n"
+        },
+        {
+            "path": "$HOME/.gitlibs",
+            "movable": true,
+            "help": "Export the following environment variables:\n\n```bash\nexport GITLIBS=\"$XDG_STATE_HOME\"/clojure/gitlibs\n```\n"
         }
     ]
 }


### PR DESCRIPTION
The Clojure programming language allows referencing dependencies via a Git repository URL, and those dependencies are cached using [tools.gitlibs](https://github.com/clojure/tools.gitlibs). By default, that puts the libraries in `~/.gitlibs`, but this can be overridden with an environment variable.