### PR TITLE
Add triton

### DIFF
--- a/programs/triton.json
+++ b/programs/triton.json
@@ -3,7 +3,7 @@
         {
             "path": "$HOME/.triton",
             "movable": true,
-            "help": "Export the following environment variables:\n\n```bash\nexport TRITON_HOME=\"$XDG_CACHE_HOME\"\n```\n"
+            "help": "Export the following environment variables:\n\n```bash\nexport TRITON_HOME=\"$XDG_CACHE_HOME/triton\"\n```\n"
         }
     ],
     "name": "triton"

--- a/programs/triton.json
+++ b/programs/triton.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.triton",
+            "movable": true,
+            "help": "Export the following environment variables:\n\n```bash\nexport TRITON_HOME=\"$XDG_CACHE_HOME\"\n```\n"
+        }
+    ],
+    "name": "triton"
+}


### PR DESCRIPTION
`export TRITON_HOME="$XDG_CACHE_HOME"` will cause triton to create the .triton folder in the xdg cache directory. That's why I didn't do `export TRITON_HOME="$XDG_CACHE_HOME/triton"` because this would result in `$XDG_CACHE_HOME/triton/.triton`