### PR TITLE
Update android to support the emulator command

### DIFF
--- a/programs/android.json
+++ b/programs/android.json
@@ -1,7 +1,7 @@
 {
     "files": [
         {
-            "help": "Export the following environment variable:\n\n```bash\nexport ANDROID_USER_HOME=\"$XDG_DATA_HOME\"/android\n```\n\nAdditionally, if you use adb, use the following alias:\n\n```bash\nalias adb='HOME=\"$XDG_DATA_HOME\"/android adb'\n```\n\n",
+            "help": "Export the following environment variable:\n\n```bash\nexport ANDROID_USER_HOME=\"$XDG_DATA_HOME\"/android\n```\n\nAdditionally, if you use adb, use the following alias:\n\n```bash\nalias adb='HOME=\"$XDG_DATA_HOME\"/android adb'\n```\n\nIf you use `emulator` command for your android emulator, export the following environment variable:\n\n```bash\nexport ANDROID_AVD_HOME=$XDG_DATA_HOME/android/avd\n```",
             "movable": true,
             "path": "$HOME/.android"
         },


### PR DESCRIPTION
The emulator launches the android emulators based on saved AVDs(Android Virtual Device). It looks at `ANDROID_AVD_HOME` to determine the location according to this error log from `emulator`
```
ERROR | (Note: Directories are searched in the order $ANDROID_AVD_HOME, $ANDROID_SDK_HOME/avd and $HOME/.android/avd)
```
So, `ANDROID_AVD_HOME` has been suggested to be set to `$XDG_DATA_HOME/android/avd`.

Alternatively, it could have been saved to `$ANDROID_USER_HOME/avd`. But in accordance to the style in `adb`'s alias suggestion this was not done.