### PR TITLE
feat: add spicetify

### DIFF
--- a/programs/spicetify.json
+++ b/programs/spicetify.json
@@ -1,0 +1,10 @@
+{
+  "name": "spicetify",
+  "files": [
+    {
+      "path": "$HOME/.spicetify",
+      "movable": true,
+      "help": "Export the following environment variable:\n\n```bash\nexport SPICETIFY_CONFIG=\"$XDG_CONFIG_HOME/spicetify\"\n```\n\nYou can move the existing dir ~/ to ~/.config as /spicetify (i.e ~/.config/spicetify)\n"
+    }
+  ]
+}

--- a/programs/spicetify.json
+++ b/programs/spicetify.json
@@ -4,7 +4,7 @@
     {
       "path": "$HOME/.spicetify",
       "movable": true,
-      "help": "Export the following environment variable:\n\n```bash\nexport SPICETIFY_CONFIG=\"$XDG_CONFIG_HOME/spicetify\"\n```\n\nYou can move the existing dir ~/ to ~/.config as /spicetify (i.e ~/.config/spicetify)\n"
+      "help": "Export the following environment variable:\n\n```bash\nexport SPICETIFY_CONFIG=\"${XDG_CONFIG_HOME:-$HOME/.config}/spicetify\"\n```\n\nYou can move the existing dir $HOME/.spicetify to ${XDG_CONFIG_HOME:-$HOME/.config}/spicetify (e.g. ~/.config/spicetify)\n"
     }
   ]
 }


### PR DESCRIPTION
Relevant discussion: https://github.com/spicetify/cli/issues/12

Spicetify by default uses the $HOME directory to store its configuration files (if no SPICETIFY_CONFIG variable is found). You can export the variable and move the existing dir to ~/.config