### PR TITLE
Update firefox and add SNI and GSConnect

### DIFF
--- a/programs/firefox.json
+++ b/programs/firefox.json
@@ -2,8 +2,8 @@
     "files": [
         {
             "path": "$HOME/.mozilla",
-            "movable": false,
-            "help": "Currently unsupported.\n\n_Relevant issue:_ https://bugzilla.mozilla.org/show_bug.cgi?id=259356\n"
+            "movable": true,
+            "help": "Supported since Firefox 147\n\nXDG is supported out-of-the-box, so we can simply move the file to _$XDG_CONFIG_HOME/mozilla_\n"
         }
     ],
     "name": "Firefox"

--- a/programs/gsconnect.json
+++ b/programs/gsconnect.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.mozilla",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant Pull request:_ https://github.com/GSConnect/gnome-shell-extension-gsconnect/pull/2156"
+        }
+    ],
+    "name": "GSConnect"
+}

--- a/programs/sni.json
+++ b/programs/sni.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.sni",
+            "movable": false,
+            "help": "Currently unsupported.\n\n_Relevant Pull request:_ https://github.com/alttpo/sni/pull/54"
+        }
+    ],
+    "name": "SNI"
+}


### PR DESCRIPTION
Firefox now support XDG spec but certain programs that use native messaging like GSConnect still create .mozilla.
Also added SNI (https://github.com/alttpo/sni)