### PR TITLE
Added the ability to make an ignore file to avoid unwanted advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Follow the instructions for your package manager to install `xdg-ninja`.
 
 ### Configuration
 
-The configuration is done in the [`./programs/`](./programs/) directory, which should be located in the same working directory as the [`xdg-ninja.sh`](./xdg-ninja.sh) script. This can be overridden with the `XN_PROGRAMS_DIR` environment variable.
+The configuration is done in the [`./programs/`](./programs/) directory, which should be located in the same working directory as the [`xdg-ninja.sh`](./xdg-ninja.sh) script. This can be overridden with the `$XN_PROGRAMS_DIR` environment variable.
 
 You define a program, and then a list of files and directories which that program ruthlessly puts into your `$HOME` directory.
 
@@ -90,6 +90,21 @@ For each file/directory, you specify if it can be (re)moved.
 If this is the case, you also specify instructions on how to accomplish this in Markdown.
 
 Files in this directory can have any name, but using the name of the program is recommended.
+
+#### Ignoring
+
+To avoid unwanted warnings, you may skip unsupported files by running `xdg-ninja --skip-unsupported`.
+
+Additionally, the you may create an ignore file at `$XDG_CONFIG_HOME/xdg-ninja/ignore` or use the `$XN_IGNOREFILE` environment variable to point to your ignorefile.
+
+Enter the [basename](https://man7.org/linux/man-pages/man1/basename.1.html) of each file or directory you wish to keep cluttering your `$HOME`. Here's an example of an ignorefile:
+
+```txt
+.zshenv
+.zshrc
+.profile
+.xinitrc
+```
 
 ### Automatically Generating Configuration
 

--- a/man/xdg-ninja.1
+++ b/man/xdg-ninja.1
@@ -1,5 +1,5 @@
 .nh
-.TH "xdg-ninja" "1" "May 2023" "b3nj5m1n" "xdg-ninja manual"
+.TH "xdg-ninja" "1" "May 2026" "b3nj5m1n" "xdg-ninja manual"
 
 .SH NAME
 .PP
@@ -33,12 +33,26 @@ Don't display anything for files that do not exist (default behavior)
 .TP
 \fB--skip-unsupported\fP
 Don't display anything for files that do not have fixes available
+.TP
+\fB--skip-user\fP
+Don't display anything for files that the user ignores (default)
+.br
+Don't display basenames in $XN_IGNOREFILE or $XDG_CONFIG_HOME/xdg-ninja/ignore. Overridden by --skip-ok.
+.TP
+\fB--no-skip-user\fP
+Don't ignore files that the user specified in the ignorefile.
+
 
 .SH ENVIRONMENT VARIABLES
 .TP
-\fBXN_PROGRAMS_DIR\fP=
+\fB$XN_PROGRAMS_DIR\fP=
 Overwrites the path where programs information are located (default: programs/
 or ../share/xdg-ninja/programs/)
+.TP
+\fB$XN_IGNOREFILE\fP=
+Is read instead of $XDG_CONFIG_HOME/xdg-ninja/ignore or $HOME/xdg-ninja/ignore.
+The ignorefile is a plain text file with the basenames of files that xdg-ninja
+will not render a warning for unless --skip-ok or --no-skip-user is specified.
 
 .SH COPYRIGHT
 .PP
@@ -49,4 +63,6 @@ There is NO WARRANTY, to the extent permitted by law.
 
 .SH SEE ALSO
 .PP
+.B basename(1), jq(1)
+.br
 Sources, bug report, and more are available at <https://github.com/b3nj5m1n/xdg-ninja>.

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -216,12 +216,12 @@ check_file() {
     HELP="$4"
 
     file=$(retrieve_existing_filename "$FILENAME")
-    base_name=$(basename "$file")
-    if [ "$SKIP_USER" = true ] && grep -qxF "$base_name" "$XN_IGNOREFILE"; then
-        # echo "Skipping $base_name from user ignore file..."
-        return
-    fi
     if [ "$file" ]; then
+        base_name=$(basename "$file")
+        if [ "$SKIP_USER" = true ] && grep -qxF "$base_name" "$XN_IGNOREFILE"; then
+          # echo "Skipping $base_name from user ignore file..."
+          return
+        fi
         if [ "$MOVABLE" = true ]; then
             log ERR "$NAME" "$file" "$HELP"
         else
@@ -245,7 +245,7 @@ do_check_programs() {
 " read -r name; read -r filename; read -r movable; read -r help; do
         check_file "$name" "$filename" "$movable" "$help"
     done <<EOF
-$(find "$XN_PROGRAMS_DIR" -type f -print0 | xargs -0 jq '.files[] as $file | .name, $file.path, $file.movable, $file.help' | sed -e 's/^"//' -e 's/"$//')
+$(find "$XN_PROGRAMS_DIR" -type f -print0 | xargs -0 jq ".files[] as \$file | .name, \$file.path, \$file.movable, \$file.help" | sed -e 's/^"//' -e 's/"$//')
 EOF
 # sed is to trim quotes
 }

--- a/xdg-ninja.sh
+++ b/xdg-ninja.sh
@@ -58,12 +58,18 @@ help() {
     ${FX_ITALIC}--help${FX_RESET}              ${FX_BOLD}This help menu${FX_RESET}
     ${FX_ITALIC}-h${FX_RESET}
 
-    ${FX_ITALIC}--no-skip-ok${FX_RESET}        ${FX_BOLD}Display messages for all files checked (verbose)${FX_RESET}
+    ${FX_ITALIC}--no-skip-ok${FX_RESET}        ${FX_BOLD}Display messages for all files, overrides --skip-user (verbose)${FX_RESET}
     ${FX_ITALIC}-v${FX_RESET}
 
     ${FX_ITALIC}--skip-ok${FX_RESET}           ${FX_BOLD}Don't display anything for files that do not exist (default)${FX_RESET}
 
     ${FX_ITALIC}--skip-unsupported${FX_RESET}  ${FX_BOLD}Don't display anything for files that do not have fixes available${FX_RESET}
+
+    ${FX_ITALIC}--skip-user${FX_RESET}         ${FX_BOLD}Don't display anything for files that the user ignores (default)${FX_RESET}
+    ${FX_ITALIC}${FX_RESET}                    Ignore basenames in \$XN_IGNOREFILE or \$XDG_CONFIG_HOME/xdg-ninja/ignore
+    ${FX_ITALIC}${FX_RESET}                    Enter the basename of each file you'd like to ignore on a new line.
+
+    ${FX_ITALIC}--no-skip-user${FX_RESET}      ${FX_BOLD}Display messages for files that the user ignores${FX_RESET}
 
     """
     printf "%b\n" "$HELPSTRING"
@@ -71,6 +77,7 @@ help() {
 
 SKIP_OK=true
 SKIP_UNSUPPORTED=false
+SKIP_USER=true
 for i in "$@"; do
     if [ "$i" = "--help" ] || [ "$i" = "-h" ]; then
         help
@@ -79,10 +86,14 @@ for i in "$@"; do
         SKIP_OK=true
     elif [ "$i" = "--no-skip-ok" ]; then
         SKIP_OK=false
-    elif [ "$i" = "--skip-unsupported" ]; then
-        SKIP_UNSUPPORTED=true
     elif [ "$i" = "-v" ]; then
         SKIP_OK=false
+    elif [ "$i" = "--skip-unsupported" ]; then
+        SKIP_UNSUPPORTED=true
+    elif [ "$i" = "--skip-user" ]; then
+        SKIP_USER=true
+    elif [ "$i" = "--no-skip-user" ]; then
+        SKIP_USER=false
     fi
 done
 
@@ -205,7 +216,11 @@ check_file() {
     HELP="$4"
 
     file=$(retrieve_existing_filename "$FILENAME")
-
+    base_name=$(basename "$file")
+    if [ "$SKIP_USER" = true ] && grep -qxF "$base_name" "$XN_IGNOREFILE"; then
+        # echo "Skipping $base_name from user ignore file..."
+        return
+    fi
     if [ "$file" ]; then
         if [ "$MOVABLE" = true ]; then
             log ERR "$NAME" "$file" "$HELP"
@@ -247,6 +262,25 @@ check_programs() {
 
 [ "$XN_PROGRAMS_DIR" ] ||
     XN_PROGRAMS_DIR="$(realpath "$0" | xargs dirname | sed 's:/bin$:/share/xdg-ninja:g')/programs"
+
+check_ignore_file() {
+    # echo "Checking ignore file..."
+    if [ -f "$XN_IGNOREFILE" ]; then
+        true
+    elif [ -f "$XDG_CONFIG_HOME"/xdg-ninja/ignore ]; then
+        XN_IGNOREFILE=$XDG_CONFIG_HOME/xdg-ninja/ignore
+    elif [ -f "$HOME"/.config/xdg-ninja/ignore ]; then
+        XN_IGNOREFILE="$HOME"/.config/xdg-ninja/ignore
+    else
+        SKIP_USER=false
+    fi
+}
+
+if [ "$SKIP_OK" = true ]; then 
+    [ "$SKIP_USER" = true ] && check_ignore_file
+else
+    SKIP_USER=false
+fi
 
 check_programs
 if [ $FIXABLE -gt 100 ]; then


### PR DESCRIPTION
Added opportunity for the user to create a file in either $XDG_CONFIG_HOME/xdg-ninja/ignore or use an environment variable $XN_IGNOREFILE to list the basenames of files they wish to keep in their $HOME even if a solution exists to move it elsewhere. This is a drop in feature, meaning existing users shouldn't need to change anything if they don't wish to use this feature.

Updated README and MANPAGE

I've been using xdg-ninja for a while, and found I often have files I wish to keep in $HOME such as .zshenv and .xinitrc, and don't like seeing warnings for those. I also wanted to be able to configure this tool without editing the ./programs directory to remove unwanted files. Feel free to let me know if this feature should be disabled by default, but since it doesn't do anything without creating the ignore file, I think it should be enabled by default. Thank you!