### PR TITLE
Add Talos Linux's talosctl config location.

### DIFF
--- a/programs/talos.json
+++ b/programs/talos.json
@@ -1,0 +1,10 @@
+{
+    "files": [
+        {
+            "path": "$HOME/.talos",
+            "movable": true,
+            "help": "Export the following environment variables:\n\n```bash\nexport TALOSCONFIG=\"$XDG_CONFIG_HOME\"/talosconfig\n```\n"
+        }
+    ],
+    "name": "talos"
+}


### PR DESCRIPTION
`~/.talos/config` can be moved with the `$TALOSCONFIG` environment variable.