### PR TITLE
Add notice about .CFUserTextEncoding on macOS.

### DIFF
--- a/programs/CFUserTextEncoding.json
+++ b/programs/CFUserTextEncoding.json
@@ -4,7 +4,7 @@
         {
             "path": "$HOME/.CFUserTextEncoding",
             "movable": false,
-            "help": "Not applicable. Probably not remvoable.\n\nFrom [Apple](https://developer.apple.com/library/archive/technotes/tn2228/_index.html#//apple_ref/doc/uid/DTS40007991-CH1-SUBSECTION15):\n\n>Core Foundation tries to access the user's home directory to determine their default text encoding (stored in the file ~/.CFUserTextEncoding).\n"
+            "help": "Not applicable. Probably not removable.\n\nFrom [Apple](https://developer.apple.com/library/archive/technotes/tn2228/_index.html#//apple_ref/doc/uid/DTS40007991-CH1-SUBSECTION15):\n\n>Core Foundation tries to access the user's home directory to determine their default text encoding (stored in the file ~/.CFUserTextEncoding).\n"
         }
     ]
 }

--- a/programs/CFUserTextEncoding.json
+++ b/programs/CFUserTextEncoding.json
@@ -1,0 +1,10 @@
+{
+    "name": "macOS Core Foundation user default text encoding",
+    "files": [
+        {
+            "path": "$HOME/.CFUserTextEncoding",
+            "movable": false,
+            "help": "Not applicable. Probably not remvoable.\n\nFrom [Apple](https://developer.apple.com/library/archive/technotes/tn2228/_index.html#//apple_ref/doc/uid/DTS40007991-CH1-SUBSECTION15):\n\n>Core Foundation tries to access the user's home directory to determine their default text encoding (stored in the file ~/.CFUserTextEncoding).\n"
+        }
+    ]
+}

--- a/programs/CFUserTextEncoding.json
+++ b/programs/CFUserTextEncoding.json
@@ -4,7 +4,7 @@
         {
             "path": "$HOME/.CFUserTextEncoding",
             "movable": false,
-            "help": "Not applicable. Probably not removable.\n\nFrom [Apple](https://developer.apple.com/library/archive/technotes/tn2228/_index.html#//apple_ref/doc/uid/DTS40007991-CH1-SUBSECTION15):\n\n>Core Foundation tries to access the user's home directory to determine their default text encoding (stored in the file ~/.CFUserTextEncoding).\n"
+            "help": "Probably not removable.\n\nIn theory, the Apple framework using this file also supports using an environment variable (_$\\_\\_CF_USER_TEXT_ENCODING_) instead. However, [Apple's own documentation](https://developer.apple.com/library/archive/technotes/tn2228/_index.html#//apple_ref/doc/uid/DTS40007991-CH1-SUBSECTION15) warns that many other frameworks may only use the file. Therefore, it is recommended to leave this file in place unless you are willing to risk text encoding bugs.\n"
         }
     ]
 }


### PR DESCRIPTION
This cannot/should not be moved/removed as far as I can tell.

References:
- https://eclecticlight.co/2020/12/10/controlling-processes-and-environments/
- https://developer.apple.com/library/archive/technotes/tn2228/_index.html